### PR TITLE
Memory for 8.0 and 7.1

### DIFF
--- a/ports/memory/Makefile
+++ b/ports/memory/Makefile
@@ -1,0 +1,7 @@
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/memory/README.md
+++ b/ports/memory/README.md
@@ -77,7 +77,8 @@ source ~/qnx800/qnxsdp-env.sh
 5. Clone the `memory` repo to the workspace
 ```bash
 #Navigate back to memory_wksp
-cd .. 
+#The docker container will put you in your home directory
+cd <path-to-workspace>
 
 #Pick one:
 #Via HTTPS
@@ -102,8 +103,8 @@ Some distributions of QNX have critical directories stored in a read-only partit
 TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
 
 #If copying to an x86_64 install, change /aarch64le/ to /x86_64/
-scp $QNX_TARGET/aarch64le/usr/local/bin/foonathan_memory_test root@$TARGET_IP_ADDRESS:/usr/bin
-scp $QNX_TARGET/aarch64le/usr/local/lib/libfoonathan_memory* root@$TARGET_IP_ADDRESS:/usr/lib
+scp $QNX_TARGET/aarch64le/usr/bin/foonathan_memory_test root@$TARGET_IP_ADDRESS:/usr/bin
+scp $QNX_TARGET/aarch64le/usr/lib/libfoonathan_memory* root@$TARGET_IP_ADDRESS:/usr/lib
 ```
 
 2. Running Tests
@@ -129,17 +130,17 @@ TARGET_USER_FOR_INSTALL="root"
 ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/memory/lib"
 
 #If copying to an x86_64 install, change /aarch64le/ to /x86_64/
-scp $QNX_TARGET/aarch64le/usr/local/bin/foonathan_memory_test root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/memory/
-scp $QNX_TARGET/aarch64le/usr/local/lib/libfoonathan_memory* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/memory/lib
-
-#Export new library path
-ssh root@$TARGET_IP_ADDRESS "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/$TARGET_USER_FOR_INSTALL/memory/lib"
+scp $QNX_TARGET/aarch64le/usr/bin/foonathan_memory_test root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/memory/
+scp $QNX_TARGET/aarch64le/usr/lib/libfoonathan_memory* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/memory/lib
 ```
 
 2. Running Tests
 ```bash
 #SSH into target
 ssh root@<target-ip-address-or-hostname>
+
+#Export new library path (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/root/memory/lib
 
 #Run test binary
 cd ~/memory/            #NOTE: ~ will direct you to the current user's home directory, 

--- a/ports/memory/README.md
+++ b/ports/memory/README.md
@@ -1,0 +1,149 @@
+### Tested for QNX 7.1 and 8.0 SDPs
+Cross-compiled on Ubuntu 24.04 for:
+- QNX 8.0 aarch64le on Raspberry Pi 4
+- QNX 7.1 x86_64 on VirtualBox 6.1
+
+Instructions for compiling and running tests are listed below.
+
+# Compile memory for SDP 7.1/8.0 on an Ubuntu Host
+1. Create a new workspace or navigate to a desired one
+```bash
+mkdir memory_wksp && cd memory_wksp
+```
+
+2. Clone the `memory` and `build_files` repos
+```bash
+#Pick one:
+#Via HTTPS
+git clone https://github.com/qnx-ports/build-files.git
+git clone https://github.com/qnx-ports/memory.git
+
+#Via SSH
+git clone git@github.com:qnx-ports/build-files.git 
+git clone git@github.com:qnx-ports/memory.git 
+```
+
+3. Source your SDP (Installed from QNX Software Center)
+```bash
+#QNX 8.0 will be in the directory ~/qnx800/
+#QNX 7.1 will be in the directory ~/qnx710/
+source ~/qnx800/qnxsdp-env.sh
+```
+
+4. Build the project in your workspace from Step 1
+```bash
+QNX_PROJECT_ROOT="$(pwd)/memory" make -C build-files/ports/memory install -j4
+```
+
+**NOTE**: Before rebuilding, you may need to delete the `/build` subdirectories and their contents in `build-files/ports/memory/nto/aarch64/le` and `build-files/ports/memory/nto/x86_64/so`. This MUST be done when changing from SDP 7.1 to 8 or vice versa, as it will link against the wrong shared objects and not show an error until testing.
+```bash
+#From your workspace:
+rm -r -f build-files/ports/memory/nto/x86_64/so/build
+rm -r -f build-files/ports/memory/nto/aarch64/le/build
+```
+
+# Compile memory for SDP 7.1/8.0 in a Docker Container
+Requires Docker: https://docs.docker.com/engine/install/
+
+1. Create a new workspace or navigate to a desired one
+```bash
+mkdir memory_wksp && cd memory_wksp
+```
+
+2. Clone the  `build_files` repo
+```bash
+#Pick one:
+#Via HTTPS
+git clone https://github.com/qnx-ports/build-files.git
+
+#Via SSH
+git clone git@github.com:qnx-ports/build-files.git 
+```
+
+3. Build the Docker image and crease a container
+```bash
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+```
+
+4. Source your SDP (Installed from QNX Software Center)
+```bash
+#QNX 8.0 will be in the directory ~/qnx800/
+#QNX 7.1 will be in the directory ~/qnx710/
+source ~/qnx800/qnxsdp-env.sh
+```
+
+5. Clone the `memory` repo to the workspace
+```bash
+#Navigate back to memory_wksp
+cd .. 
+
+#Pick one:
+#Via HTTPS
+git clone https://github.com/qnx-ports/memory.git
+
+#Via SSH
+git clone git@github.com:qnx-ports/memory.git
+```
+
+6. Build the project in your workspace from Step 1
+```bash
+QNX_PROJECT_ROOT="$(pwd)/memory" make -C build-files/ports/memory install -j4
+```
+
+# Running Tests on a Target
+Some distributions of QNX have critical directories stored in a read-only partition (`/`, `/system`, `/etc`, etc). Included in these are the default `bin` and `lib` directories. If this is the case, follow the "Installing in home directory" instructions
+
+### Installing in /usr/ (default)
+1. Installation
+```bash
+#Set your target's IP here
+TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
+
+#If copying to an x86_64 install, change /aarch64le/ to /x86_64/
+scp $QNX_TARGET/aarch64le/usr/local/bin/foonathan_memory_test root@$TARGET_IP_ADDRESS:/usr/bin
+scp $QNX_TARGET/aarch64le/usr/local/lib/libfoonathan_memory* root@$TARGET_IP_ADDRESS:/usr/lib
+```
+
+2. Running Tests
+```bash
+#SSH into target
+ssh root@<target-ip-address-or-hostname>
+
+#Run test binary
+cd /usr/bin
+./foonathan_memory_test
+```
+
+### Installing in home directory
+1. Installation
+```bash
+#Set your target's IP here
+TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
+
+#Select the home directory to install to (this will install to /data/home/root)
+TARGET_USER_FOR_INSTALL="root"
+
+#Create new directories on the target
+ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/memory/lib"
+
+#If copying to an x86_64 install, change /aarch64le/ to /x86_64/
+scp $QNX_TARGET/aarch64le/usr/local/bin/foonathan_memory_test root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/memory/
+scp $QNX_TARGET/aarch64le/usr/local/lib/libfoonathan_memory* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/memory/lib
+
+#Export new library path
+ssh root@$TARGET_IP_ADDRESS "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/$TARGET_USER_FOR_INSTALL/memory/lib"
+```
+
+2. Running Tests
+```bash
+#SSH into target
+ssh root@<target-ip-address-or-hostname>
+
+#Run test binary
+cd ~/memory/            #NOTE: ~ will direct you to the current user's home directory, 
+                        #which may be incorrect depending on your choices above. 
+                        #Navigate to /data/home to see all user home directories
+./foonathan_memory_test
+```

--- a/ports/memory/common.mk
+++ b/ports/memory/common.mk
@@ -51,7 +51,7 @@ MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
 ifndef NO_TARGET_OVERRIDE
 memory_all:
 	@mkdir -p build
-	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)/../
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)/
 	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
 
 install check: memory_all

--- a/ports/memory/common.mk
+++ b/ports/memory/common.mk
@@ -1,0 +1,82 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+NAME=memory
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+MEMORY_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+MEMORY_VERSION = 0.7-3
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#set the following to FALSE if generating .pinfo files is causing problems
+GENERATE_PINFO_FILES ?= TRUE
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = memory_all
+.PHONY: memory_all install check clean
+
+CFLAGS += $(FLAGS)
+LDFLAGS += -Wl,--build-id=md5
+
+define PINFO
+endef
+PINFO_STATE=Experimental
+USEFILE=
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_LIBDIR=$(MEMORY_INSTALL_ROOT)/$(CPUVARDIR)/usr/lib \
+             -DCMAKE_INSTALL_PREFIX=$(MEMORY_INSTALL_ROOT)/$(CPUVARDIR)/usr \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DBUILD_SHARED_LIBS=1 \
+             -DDOCTEST_USE_STD_HEADERS=ON
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+ifndef NO_TARGET_OVERRIDE
+memory_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)/../
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: memory_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install all $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -fr build
+
+uninstall:
+endif
+
+#everything down below deals with the generation of the PINFO
+#information for shared objects that is used by the QNX build
+#infrastructure to embed metadata in the .so files, for example
+#data and time, version number, description, etc. Metadata can
+#be retrieved on the target by typing 'use -i <path to openblas .so file>'.
+#this is optional: setting GENERATE_PINFO_FILES to FALSE will disable
+#the insertion of metadata in .so files.
+ifeq ($(GENERATE_PINFO_FILES), TRUE)
+#the following rules are called by the cmake generated makefiles,
+#in order to generate the .pinfo files for the shared libraries
+%.so$(MEMORY_VERSION):
+	$(ADD_PINFO)
+	$(ADD_USAGE)
+
+endif

--- a/ports/memory/nto/Makefile
+++ b/ports/memory/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/memory/nto/aarch64/Makefile
+++ b/ports/memory/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/memory/nto/aarch64/le/Makefile
+++ b/ports/memory/nto/aarch64/le/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64
+FLAGS      += $(VFLAG_le) $(CCVFLAG_le)
+LDFLAGS    += $(VFLAG_le) $(LDVFLAG_le)

--- a/ports/memory/nto/x86_64/Makefile
+++ b/ports/memory/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/memory/nto/x86_64/so/Makefile
+++ b/ports/memory/nto/x86_64/so/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64
+FLAGS      += $(VFLAG) $(CCVFLAG)
+LDFLAGS    += $(VFLAG) $(LDVFLAG)

--- a/ports/memory/qnx.nto.toolchain.cmake
+++ b/ports/memory/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} -std=gnu++11 ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")


### PR DESCRIPTION
After taking a look at the old memory port, I updated the build files for 7.1 to support 8.0 and work in thew new format. 

I have also created installation instructions and tested building & running for 8.0 and 7.1