### PR TITLE
Add clapack Build Files

### DIFF
--- a/.github/workflows/clapack.yml
+++ b/.github/workflows/clapack.yml
@@ -1,0 +1,60 @@
+name: clapack
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  build:
+    runs-on: build-files-runner
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'clapack'))
+    steps:
+    - name: Checkout build-files
+      uses: actions/checkout@v4
+      with:
+        path: build-files
+
+    - name: Checkout clapack
+      uses: actions/checkout@v4
+      with:
+        repository: qnx-ports/clapack
+        path: clapack
+
+    - name: Download SDP 8.0
+      env:
+        LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
+        MYQNX_USER: ${{ secrets.MYQNX_USER }}
+        MYQNX_PASSWORD: ${{ secrets.MYQNX_PASSWORD }}
+      run: |
+        echo "Downloading QNX Software Center ..."
+        mkdir ${{ github.workspace }}/.qnx
+        curl -v --cookie-jar ${{ github.workspace }}/.qnx/myqnxcookies.auth --form "userlogin=$MYQNX_USER" --form "password=$MYQNX_PASSWORD" -X POST https://www.qnx.com/account/login.html > login_response.html
+        curl -v -L --cookie ${{ github.workspace }}/.qnx/myqnxcookies.auth https://www.qnx.com/download/download/77351/qnx-setup-2.0.3-202408131717-linux.run > qnx-setup-lin.run
+        chmod a+x qnx-setup-lin.run
+        ./qnx-setup-lin.run force-override disable-auto-start agree-to-license-terms ${{ github.workspace }}/qnxinstall
+        echo "Installing License ..."
+        ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -syncLicenseKeys -myqnx.user="$MYQNX_USER" -myqnx.password="$MYQNX_PASSWORD" -addLicenseKey $LICENSE_KEY
+        cp -r ~/.qnx/license ${{ github.workspace }}/.qnx
+        echo "Downloading QNX SDP ..."
+        ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$MYQNX_USER" -myqnx.password="$MYQNX_PASSWORD"
+
+    - name: Build the Docker image
+      run: |
+        cd build-files/docker && ./docker-build-qnx-image.sh
+
+    - name: Build clapack
+      uses: addnab/docker-run-action@v3
+      with:
+        image: qnx800:latest
+        options: -v ${{ github.workspace }}:/home/runner
+        shell: bash
+        run: |
+          source ~/qnx800/qnxsdp-env.sh
+          QNX_PROJECT_ROOT="$(pwd)/clapack" make -C build-files/ports/clapack install -j$(nproc)

--- a/ports/clapack/Makefile
+++ b/ports/clapack/Makefile
@@ -1,0 +1,33 @@
+TARGETS = linux-x86_64-o nto-aarch64-le nto-x86_64-o
+CLEAN_TARGETS = $(addprefix clean-,$(TARGETS))
+# Do not install linux-x86_64-o -- it is only here to help with the build process
+INSTALL_TARGETS = $(addprefix install-,$(filter-out linux-x86_64-o,$(TARGETS)))
+
+ifdef INSTALL_ROOT_nto
+PASSTHROUGH_ARGS = INSTALL_ROOT_nto=$(INSTALL_ROOT_nto)
+endif
+
+ifdef USE_INSTALL_ROOT
+PASSTHROUGH_ARGS += USE_INSTALL_ROOT=$(USE_INSTALL_ROOT)
+endif
+
+ifdef JLEVEL
+PASSTHROUGH_ARGS += JLEVEL=$(JLEVEL)
+endif
+
+.PHONY: $(TARGETS) clean install
+
+all: $(TARGETS)
+clean: $(CLEAN_TARGETS)
+install: $(INSTALL_TARGETS)
+
+$(TARGETS): %:
+	make -C $@ $(PASSTHROUGH_ARGS)
+$(CLEAN_TARGETS): clean-%:
+	make -C $* $(PASSTHROUGH_ARGS) clean
+$(INSTALL_TARGETS): install-%: %
+	make -C $* $(PASSTHROUGH_ARGS) install
+
+# Require host build first
+nto-aarch64-le: linux-x86_64-o
+nto-x86_64-o: linux-x86_64-o

--- a/ports/clapack/README.md
+++ b/ports/clapack/README.md
@@ -1,0 +1,178 @@
+### Tested so far:
+Cross-compiled on Ubuntu 24.04 via WSL for:
+- QNX 8.0 aarch64le on Raspberry Pi 4
+
+Instructions for compiling and running tests are listed below.
+
+# Compile CLAPACK for SDP 7.1/8.0 on Ubuntu Host
+1. Create new workspace or navigate to a desired one
+```bash
+mkdir clapack_wksp && cd clapack_wksp
+```
+
+
+2. Clone `build_files` and `clapack`
+```bash
+#Pick one:
+#Via HTTPS
+git clone https://github.com/qnx-ports/build-files.git
+git clone --TODO--
+
+#Via SSH
+git clone git@github.com:qnx-ports/build-files.git 
+git clone --TODO--
+```
+
+3. Source your SDP (Installed from QNX Software Center)
+```bash
+#QNX 8.0 will be in the directory ~/qnx800/
+#QNX 7.1 will be in the directory ~/qnx710/
+source ~/qnx800/qnxsdp-env.sh
+```
+
+4. Build the project in your workspace from Step 1
+```bash
+#Default:
+make -C build-files/ports/clapack install
+
+#If you cloned clapack to somewhere else, you can specify the correct path to the directory as such:
+QNX_PROJECT_ROOT=/path/to/clapack make -C build-files/ports/clapack install
+
+#By default, tests are built for the shell /bin/sh . If you have mounted the target IFS's differently, you can specify the path to your desired shell as follows:
+TEST_TARGET_SHELL=/path/to/sh make -C build-files/ports/clapack install
+```
+
+
+**NOTE**: Before rebuilding, you may need to delete the `/build` subdirectories and their contents in the `build-files/ports/clapack/*/*` subfolders. This should be done when changing from SDP 7.1 to 8 or vice versa.
+```bash
+#From your workspace:
+rm -r -f build-files/ports/clapack/linux-x86_64-o/build
+rm -r -f build-files/ports/clapack/nto-aarch64-le/build
+rm -r -f build-files/ports/clapack/nto-x86_64-o/build
+```
+
+# Docker --TODO--
+
+# Running Tests on a Target
+Some distributions of QNX have critical directories stored in a read-only partition (`/`, `/system`, `/etc`, etc). Included in these are the default `bin` and `lib` directories. If this is the case, follow the "Installing in home directory" instructions
+
+### Installing in /usr/ (default) --TODO--
+
+
+### Installing in home directory SDP 8.0
+1. Installation
+```bash
+#Set your target's IP here
+TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
+
+#Select the home directory to install to (this will install to /data/home/root)
+TARGET_USER_FOR_INSTALL="root"
+
+#Create new directories on the target
+ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/lib"
+ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/test"
+
+#If copying to an x86_64 install, change /aarch64le/ to /x86_64/
+scp $QNX_TARGET/aarch64le/usr/local/bin/clapack_tests/* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/test
+scp $QNX_TARGET/aarch64le/usr/lib/libf2c.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/liblapack.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/libblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/libopenblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/libtmglib.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+```
+
+2. Running Tests
+```bash
+#SSH into target
+ssh root@<target-ip-address-or-hostname>
+
+#Export new library path (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/root/clapack/lib
+
+#Change to test directory (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
+cd /data/home/root/clapack/test
+
+#Note: as tests are .sh files, you may need to give them permissions
+chmod 744 *.sh
+
+#Run one test
+./<test-name>.sh
+```
+Running all tests for clapack takes some time, but can be done through a simple shell script.
+
+Copy the following into a .sh file located in the same directory as your tests, and use `chmod` to give it proper permissions.
+```bash
+#! /bin/sh
+echo "Finding tests..."
+for f in *.sh; do
+    echo "$f"
+done
+
+echo "Running tests..."
+for f in *.sh; do
+    echo "Running $f"
+    bash "$f"
+done
+
+echo "Complete"
+```
+Note that each individual test script is composed of hundreds to thousands of tests, of which not all will pass. That is expected for floating point within a certain margin of error. If a test script exceeds its margin of error, it will exit with a positive error code.
+
+### Installing in home directory SDP 7.1
+1. Installation
+```bash
+#Set your target's IP here
+TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
+
+#Select the home directory to install to (this will install to /data/home/root)
+TARGET_USER_FOR_INSTALL="root"
+
+#Create new directories on the target
+ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/lib"
+ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/test"
+
+#If copying to an x86_64 install, change /aarch64le/ to /x86_64/
+scp $QNX_TARGET/aarch64le/usr/local/bin/clapack_tests/* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/test
+scp $QNX_TARGET/aarch64le/usr/local/lib/libf2c.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/liblapack.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/libblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/libopenblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/libtmglib.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+```
+
+2. Running Tests
+```bash
+#SSH into target
+ssh root@<target-ip-address-or-hostname>
+
+#Export new library path (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/root/clapack/lib
+
+#Change to test directory (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
+cd /data/home/root/clapack/test
+
+#Note: as tests are .sh files, you may need to give them permissions
+chmod 744 *.sh
+
+#Run one test
+./<test-name>.sh
+```
+Running all tests for clapack takes some time, but can be done through a simple shell script.
+
+Copy the following into a .sh file located in the same directory as your tests, and use `chmod` to give it proper permissions.
+```bash
+#! /bin/sh
+echo "Finding tests..."
+for f in *.sh; do
+    echo "$f"
+done
+
+echo "Running tests..."
+for f in *.sh; do
+    echo "Running $f"
+    bash "$f"
+done
+
+echo "Complete"
+```
+Note that each individual test script is composed of hundreds to thousands of tests, of which not all will pass. That is expected for floating point within a certain margin of error. If a test script exceeds its margin of error, it will exit with a positive error code.

--- a/ports/clapack/README.md
+++ b/ports/clapack/README.md
@@ -45,9 +45,7 @@ TEST_TARGET_SHELL=/path/to/sh make -C build-files/ports/clapack install
 **NOTE**: Before rebuilding, you may need to delete the `/build` subdirectories and their contents in the `build-files/ports/clapack/*/*` subfolders. This should be done when changing from SDP 7.1 to 8 or vice versa.
 ```bash
 #From your workspace:
-rm -r -f build-files/ports/clapack/linux-x86_64-o/build
-rm -r -f build-files/ports/clapack/nto-aarch64-le/build
-rm -r -f build-files/ports/clapack/nto-x86_64-o/build
+make -C build-files/ports/clapack clean
 ```
 
 # Compile CLAPACK for SDP 7.1/8.0 in Docker
@@ -110,9 +108,7 @@ TEST_TARGET_SHELL=/path/to/sh make -C build-files/ports/clapack install
 **NOTE**: Before rebuilding, you may need to delete the `/build` subdirectories and their contents in the `build-files/ports/clapack/*/*` subfolders. This should be done when changing from SDP 7.1 to 8 or vice versa.
 ```bash
 #From your workspace:
-rm -r -f build-files/ports/clapack/linux-x86_64-o/build
-rm -r -f build-files/ports/clapack/nto-aarch64-le/build
-rm -r -f build-files/ports/clapack/nto-x86_64-o/build
+make -C build-files/ports/clapack clean
 ```
 
 

--- a/ports/clapack/README.md
+++ b/ports/clapack/README.md
@@ -122,32 +122,32 @@ Some distributions of QNX have critical directories stored in a read-only partit
 #Set your target's IP here
 TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
 
-#Select the home directory to install to (this will install to /data/home/root)
-TARGET_USER_FOR_INSTALL="root"
+#Select the home directory to install to (this will install to /data/home/qnxuser)
+TARGET_USER_FOR_INSTALL="qnxuser"
 
 #Create new directories on the target
-ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/lib"
-ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/test"
+ssh qnxuser@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/lib"
+ssh qnxuser@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/test"
 
 #If copying to an x86_64 install, change /aarch64le/ to /x86_64/
-scp $QNX_TARGET/aarch64le/usr/local/bin/clapack_tests/* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/test
-scp $QNX_TARGET/aarch64le/usr/lib/libf2c.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/lib/liblapack.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/lib/libblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/lib/libopenblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/lib/libtmglib.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/bin/clapack_tests/* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/test
+scp $QNX_TARGET/aarch64le/usr/lib/libf2c.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/liblapack.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/libblas.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/libopenblas.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/lib/libtmglib.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
 ```
 
 2. Running Tests
 ```bash
 #SSH into target
-ssh root@<target-ip-address-or-hostname>
+ssh qnxuser@<target-ip-address-or-hostname>
 
-#Export new library path (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/root/clapack/lib
+#Export new library path (Change qnxuser to whatever you set for TARGET_USER_FOR_INSTALL)
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/qnxuser/clapack/lib
 
-#Change to test directory (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
-cd /data/home/root/clapack/test
+#Change to test directory (Change qnxuser to whatever you set for TARGET_USER_FOR_INSTALL)
+cd /data/home/qnxuser/clapack/test
 
 #Note: as tests are .sh files, you may need to give them permissions
 chmod 744 *.sh
@@ -181,32 +181,32 @@ Note that each individual test script is composed of hundreds to thousands of te
 #Set your target's IP here
 TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
 
-#Select the home directory to install to (this will install to /data/home/root)
-TARGET_USER_FOR_INSTALL="root"
+#Select the home directory to install to (this will install to /data/home/qnxuser)
+TARGET_USER_FOR_INSTALL="qnxuser"
 
 #Create new directories on the target
-ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/lib"
-ssh root@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/test"
+ssh qnxuser@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/lib"
+ssh qnxuser@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER_FOR_INSTALL/clapack/test"
 
 #If copying to an x86_64 install, change /aarch64le/ to /x86_64/
-scp $QNX_TARGET/aarch64le/usr/local/bin/clapack_tests/* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/test
-scp $QNX_TARGET/aarch64le/usr/local/lib/libf2c.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/local/lib/liblapack.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/local/lib/libblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/local/lib/libopenblas.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
-scp $QNX_TARGET/aarch64le/usr/local/lib/libtmglib.so* root@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/bin/clapack_tests/* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/test
+scp $QNX_TARGET/aarch64le/usr/local/lib/libf2c.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/liblapack.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/libblas.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/libopenblas.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/libtmglib.so* qnxuser@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER_FOR_INSTALL/clapack/lib
 ```
 
 2. Running Tests
 ```bash
 #SSH into target
-ssh root@<target-ip-address-or-hostname>
+ssh qnxuser@<target-ip-address-or-hostname>
 
-#Export new library path (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/root/clapack/lib
+#Export new library path (Change qnxuser to whatever you set for TARGET_USER_FOR_INSTALL)
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/data/home/qnxuser/clapack/lib
 
-#Change to test directory (Change root to whatever you set for TARGET_USER_FOR_INSTALL)
-cd /data/home/root/clapack/test
+#Change to test directory (Change qnxuser to whatever you set for TARGET_USER_FOR_INSTALL)
+cd /data/home/qnxuser/clapack/test
 
 #Note: as tests are .sh files, you may need to give them permissions
 chmod 744 *.sh

--- a/ports/clapack/README.md
+++ b/ports/clapack/README.md
@@ -10,17 +10,16 @@ Instructions for compiling and running tests are listed below.
 mkdir clapack_wksp && cd clapack_wksp
 ```
 
-
 2. Clone `build_files` and `clapack`
 ```bash
 #Pick one:
 #Via HTTPS
 git clone https://github.com/qnx-ports/build-files.git
-git clone --TODO--
+git clone https://github.com/qnx-ports/clapack.git
 
 #Via SSH
 git clone git@github.com:qnx-ports/build-files.git 
-git clone --TODO--
+git clone git@github.com:qnx-ports/clapack.git
 ```
 
 3. Source your SDP (Installed from QNX Software Center)
@@ -51,12 +50,74 @@ rm -r -f build-files/ports/clapack/nto-aarch64-le/build
 rm -r -f build-files/ports/clapack/nto-x86_64-o/build
 ```
 
-# Docker --TODO--
+# Compile CLAPACK for SDP 7.1/8.0 in Docker
+1. Create new workspace or navigate to a desired one
+```bash
+mkdir clapack_wksp && cd clapack_wksp
+```
+
+2. Clone the `build_files` repo
+```bash
+#Pick one:
+#Via HTTPS
+git clone https://github.com/qnx-ports/build-files.git
+
+#Via SSH
+git clone git@github.com:qnx-ports/build-files.git 
+```
+
+3. Build the Docker image and create a container
+```bash
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+```
+
+4. Source your SDP (Installed from QNX Software Center)
+```bash
+#QNX 8.0 will be in the directory ~/qnx800/
+#QNX 7.1 will be in the directory ~/qnx710/
+source ~/qnx800/qnxsdp-env.sh
+```
+
+5. Clone the `clapack` repo
+```bash
+#Navigate back to memory_wksp
+#The docker container will put you in your home directory
+cd <path-to-workspace>
+
+#Pick one:
+#Via HTTPS
+git clone https://github.com/qnx-ports/clapack.git
+
+#Via SSH
+git clone git@github.com:qnx-ports/clapack.git 
+```
+
+6. Build the project in your workspace from Step 1
+```bash
+#Default:
+make -C build-files/ports/clapack install
+
+#If you cloned clapack to somewhere else, you can specify the correct path to the directory as such:
+QNX_PROJECT_ROOT=/path/to/clapack make -C build-files/ports/clapack install
+
+#By default, tests are built for the shell /bin/sh . If you have mounted the target IFS's differently, you can specify the path to your desired shell as follows:
+TEST_TARGET_SHELL=/path/to/sh make -C build-files/ports/clapack install
+```
+
+
+**NOTE**: Before rebuilding, you may need to delete the `/build` subdirectories and their contents in the `build-files/ports/clapack/*/*` subfolders. This should be done when changing from SDP 7.1 to 8 or vice versa.
+```bash
+#From your workspace:
+rm -r -f build-files/ports/clapack/linux-x86_64-o/build
+rm -r -f build-files/ports/clapack/nto-aarch64-le/build
+rm -r -f build-files/ports/clapack/nto-x86_64-o/build
+```
+
 
 # Running Tests on a Target
 Some distributions of QNX have critical directories stored in a read-only partition (`/`, `/system`, `/etc`, etc). Included in these are the default `bin` and `lib` directories. If this is the case, follow the "Installing in home directory" instructions
-
-### Installing in /usr/ (default) --TODO--
 
 
 ### Installing in home directory SDP 8.0

--- a/ports/clapack/common.mk
+++ b/ports/clapack/common.mk
@@ -1,0 +1,47 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+include $(MKFILES_ROOT)/qmacros.mk
+
+NAME=clapack
+
+DIST_BASE=$(PROJECT_ROOT)/../../../clapack
+
+ifdef QNX_PROJECT_ROOT
+DIST_BASE=$(QNX_PROJECT_ROOT)
+endif
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Debug
+
+#CLAPACK-specific: Test Shell
+ifndef TEST_TARGET_SHELL
+export TEST_TARGET_SHELL=/bin/sh
+endif
+
+ALL_DEPENDENCIES = clapack_all
+.PHONY: clapack_all install check clean
+
+CFLAGS += $(FLAGS)
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+clapack_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(DIST_BASE)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: clapack_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -rf build
+
+uninstall:
+

--- a/ports/clapack/host.mk
+++ b/ports/clapack/host.mk
@@ -1,0 +1,4 @@
+CMAKE_ARGS = -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)
+
+install check:
+	@echo "Installation of host binaries is disabled"

--- a/ports/clapack/linux-x86_64-o/Makefile
+++ b/ports/clapack/linux-x86_64-o/Makefile
@@ -1,0 +1,2 @@
+include ../common.mk
+include ../host.mk

--- a/ports/clapack/nto-aarch64-le/Makefile
+++ b/ports/clapack/nto-aarch64-le/Makefile
@@ -1,0 +1,2 @@
+include ../common.mk
+include ../target.mk

--- a/ports/clapack/nto-x86_64-o/Makefile
+++ b/ports/clapack/nto-x86_64-o/Makefile
@@ -1,0 +1,2 @@
+include ../common.mk
+include ../target.mk

--- a/ports/clapack/qnx.nto.toolchain.cmake
+++ b/ports/clapack/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")

--- a/ports/clapack/target.mk
+++ b/ports/clapack/target.mk
@@ -1,0 +1,54 @@
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+LDFLAGS += -Wl,--build-id=md5
+
+#Search paths for all of CMake's find_* functions --
+#headers, libraries, etc.
+#
+#$(QNX_TARGET): for architecture-agnostic files shipped with SDP (e.g. headers)
+#$(QNX_TARGET)/$(CPUVARDIR): for architecture-specific files in SDP
+#$(INSTALL_ROOT)/$(CPUVARDIR): any packages that may have been installed in the staging area
+CMAKE_FIND_ROOT_PATH := $(QNX_TARGET);$(QNX_TARGET)/$(CPUVARDIR);$(INSTALL_ROOT)/$(CPUVARDIR)
+
+#Path to CMake modules; These are CMake files installed by other packages
+#for downstreams to discover them automatically. We support discovering
+#CMake-based packages from inside SDP or in the staging area.
+#Note that CMake modules can automatically detect the prefix they are
+#installed in.
+CMAKE_MODULE_PATH := $(QNX_TARGET)/$(CPUVARDIR)/$(PREFIX)/lib/cmake;$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib/cmake
+
+#Headers from INSTALL_ROOT need to be made available by default
+#because CMake and pkg-config do not necessary add it automatically
+#if the include path is "default"
+CFLAGS += -I$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/include
+
+#This should have been built by the linux-x86_64-o target
+#see the main Makefile
+export ARITHCHK=$(PROJECT_ROOT)/linux-x86_64-o/build/F2CLIBS/libf2c/arithchk
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_SYSTEM_PROCESSOR="$(CPUVARDIR)" \
+             -DCMAKE_INSTALL_PREFIX="$(PREFIX)" \
+             -DCMAKE_STAGING_PREFIX="$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)" \
+             -DCMAKE_MODULE_PATH="$(CMAKE_MODULE_PATH)" \
+             -DCMAKE_FIND_ROOT_PATH="$(CMAKE_FIND_ROOT_PATH)" \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DBUILD_SHARED_LIBS=ON \
+             -DCLAPACK_BUILD_TESTS=ON \
+             -DCLAPACK_INSTALL_TESTS=ON \


### PR DESCRIPTION
Migrated from GitLab build files, which added the following:
-Compatibility with QNX
-Generation of test .sh files for running tests

Added the following additional features:
-README with in-depth instructions
-Ability to change shell binary in generated tests via environment variable TEST_SHELL (in fork qnx-ports/clapack)
---Set default to /bin/sh

Changed the following for parity:
-Added QNX_PROJECT_ROOT environment variable support for build-files compilation
----Set default to ../../../clapack (Location of clapack if both are cloned in the same directory)