### PR TITLE
libjson files

### DIFF
--- a/.github/workflows/libjson.yml
+++ b/.github/workflows/libjson.yml
@@ -1,0 +1,70 @@
+name: libjson
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/libjson.yml'
+      - 'docker/**'
+      - 'ports/libjson/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/libjson.yml'
+      - 'docker/**'
+      - 'ports/libjson/**'
+
+jobs:
+
+  build:
+    runs-on: self-hosted
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'libjson'))
+    steps:
+    - name: Checkout build-files
+      uses: actions/checkout@v4
+      with:
+        path: build-files
+
+    - name: Checkout libjson
+      uses: actions/checkout@v4
+      with:
+        repository: vincenthz/libjson
+        path: libjson
+
+    - name: Download SDP 8.0
+      env:
+        LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
+        MYQNX_USER: ${{ secrets.MYQNX_USER }}
+        MYQNX_PASSWORD: ${{ secrets.MYQNX_PASSWORD }}
+      run: |
+        echo "Downloading QNX Software Center ..."
+        mkdir ${{ github.workspace }}/.qnx
+        curl -v --cookie-jar ${{ github.workspace }}/.qnx/myqnxcookies.auth --form "userlogin=$MYQNX_USER" --form "password=$MYQNX_PASSWORD" -X POST https://www.qnx.com/account/login.html > login_response.html
+        curl -v -L --cookie ${{ github.workspace }}/.qnx/myqnxcookies.auth https://www.qnx.com/download/download/77351/qnx-setup-2.0.3-202408131717-linux.run > qnx-setup-lin.run
+        chmod a+x qnx-setup-lin.run
+        ./qnx-setup-lin.run force-override disable-auto-start agree-to-license-terms ${{ github.workspace }}/qnxinstall
+        echo "Installing License ..."
+        ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -syncLicenseKeys -myqnx.user="$MYQNX_USER" -myqnx.password="$MYQNX_PASSWORD" -addLicenseKey $LICENSE_KEY
+        cp -r ~/.qnx/license ${{ github.workspace }}/.qnx
+        echo "Downloading QNX SDP ..."
+        ${{ github.workspace }}/qnxinstall/qnxsoftwarecenter/qnxsoftwarecenter_clt -mirror -cleanInstall -destination ${{ github.workspace }}/qnx800 -installBaseline com.qnx.qnx800 -myqnx.user="$MYQNX_USER" -myqnx.password="$MYQNX_PASSWORD"
+
+    - name: Build the Docker image
+      run: |
+        cd build-files/docker && ./docker-build-qnx-image.sh
+
+    - name: Build libjson
+      uses: addnab/docker-run-action@v3
+      with:
+        image: qnx800:latest
+        options: -v ${{ github.workspace }}:/home/runner
+        shell: bash
+        run: |
+          source ~/qnx800/qnxsdp-env.sh
+          QNX_PROJECT_ROOT="$(pwd)/libjson" make -C build-files/ports/libjson install -j$(nproc)

--- a/ports/libjson/CMakeLists.txt
+++ b/ports/libjson/CMakeLists.txt
@@ -4,12 +4,13 @@
 #--------------------------------------------
 # Verify correct version
 cmake_minimum_required ( VERSION 3.5 )
+project ( libjson )
 
 #--------------------------------------------
 # Set up environment variables
-set ( MAJOR_VERSION 1 )
-set ( MINOR_VERSION 0 )
-set ( MICRO_VERSION 0 )
+set ( MAJOR_VERSION %MAJOR% )
+set ( MINOR_VERSION %MINOR% )
+set ( MICRO_VERSION %MICRO% )
 
 #--------------------------------------------
 # Library

--- a/ports/libjson/CMakeLists.txt
+++ b/ports/libjson/CMakeLists.txt
@@ -32,19 +32,19 @@ add_executable ( jsonlint
 # Installation
 install (
     TARGETS             json
-    DESTINATION         lib
+    DESTINATION         ${CMAKE_INSTALL_LIBDIR}
 )
 install (
     TARGETS             jsonlint
-    DESTINATION         local/libjson_tests
+    DESTINATION         ${CMAKE_INSTALL_BINDIR}/libjson_tests
 )
 install (
     DIRECTORY           tests/
-    DESTINATION         local/libjson_tests/test
+    DESTINATION         ${CMAKE_INSTALL_BINDIR}/libjson_tests/test
 )
 install (
     FILES               json.h
-    DESTINATION         include/libjson
+    DESTINATION         ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 

--- a/ports/libjson/CMakeLists.txt
+++ b/ports/libjson/CMakeLists.txt
@@ -17,28 +17,26 @@ add_library ( json SHARED
     json.c
 )
 set_target_properties ( json PROPERTIES
-    VERSION     ${MAJOR_VERSION}.${MINOR_VERSION}.${MICRO_VERSION}
-    SOVERSION   ${MAJOR_VERSION}
+    VERSION             ${MAJOR_VERSION}.${MINOR_VERSION}.${MICRO_VERSION}
+    SOVERSION           ${MAJOR_VERSION}
 )
 
 #-------------------------------------------
 # Test Executable
 add_executable ( jsonlint
     jsonlint.c
-)
-target_link_libraries ( jsonlint
-    PRIVATE     json
+    json.c
 )
 
 #-------------------------------------------
 # Installation
 install (
     TARGETS             json
-    LIBRARY DESTINATION lib
+    DESTINATION         lib
 )
 install (
     TARGETS             jsonlint
-    RUNTIME DESTINATION local/libjson_tests
+    DESTINATION         local/libjson_tests
 )
 install (
     DIRECTORY           tests/

--- a/ports/libjson/CMakeLists.txt
+++ b/ports/libjson/CMakeLists.txt
@@ -1,0 +1,52 @@
+# QNX CMakeLists.txt
+# Made for cross-compiling libjson with QNX
+
+#--------------------------------------------
+# Verify correct version
+cmake_minimum_required ( VERSION 3.5 )
+
+#--------------------------------------------
+# Set up environment variables
+set ( MAJOR_VERSION 1 )
+set ( MINOR_VERSION 0 )
+set ( MICRO_VERSION 0 )
+
+#--------------------------------------------
+# Library
+add_library ( json SHARED
+    json.c
+)
+set_target_properties ( json PROPERTIES
+    VERSION     ${MAJOR_VERSION}.${MINOR_VERSION}.${MICRO_VERSION}
+    SOVERSION   ${MAJOR_VERSION}
+)
+
+#-------------------------------------------
+# Test Executable
+add_executable ( jsonlint
+    jsonlint.c
+)
+target_link_libraries ( jsonlint
+    PRIVATE     json
+)
+
+#-------------------------------------------
+# Installation
+install (
+    TARGETS             json
+    LIBRARY DESTINATION lib
+)
+install (
+    TARGETS             jsonlint
+    RUNTIME DESTINATION local/libjson_tests
+)
+install (
+    DIRECTORY           tests/
+    DESTINATION         local/libjson_tests/test
+)
+install (
+    FILES               json.h
+    DESTINATION         include/libjson
+)
+
+

--- a/ports/libjson/Makefile
+++ b/ports/libjson/Makefile
@@ -1,0 +1,8 @@
+LIST=OS CPU VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/libjson/README.md
+++ b/ports/libjson/README.md
@@ -65,11 +65,11 @@ ssh $TARGET_USER@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER/libjson/li
 
 # Install Test Setup
 #->Change aarch64le to match your architecture (i.e. x86_64, etc)
-scp -r $QNX_TARGET/aarch64le/usr/local/libjson_tests/* $TARGET_USER@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER/libjson
+scp -r $QNX_TARGET/aarch64le/usr/local/bin/libjson_tests/* $TARGET_USER@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER/libjson
 
 # OPTIONAL: Installed shared objects
 #->These are NOT required for tests, as they are not linked per the recommendation of the libjson authors.
-scp $QNX_TARGET/aarch64le/usr/lib/libjson.so* $TARGET_USER@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER/libjson/lib
+scp $QNX_TARGET/aarch64le/usr/local/lib/libjson.so* $TARGET_USER@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER/libjson/lib
 ```
 
 2. Running Tests

--- a/ports/libjson/README.md
+++ b/ports/libjson/README.md
@@ -1,0 +1,83 @@
+### Tested for QNX 7.1 and 8.0 SDPs
+Cross-compiled on Ubuntu 24.04 for:
+- QNX 8.0 aarch64le on Raspberry Pi 4
+- QNX 7.1 x86_64 on VirtualBox 6.1
+
+__*IMPORTANT NOTE*__: The author of libjson recommends *against* building it as a shared object and linking against it. As of 12/10/2024, the author recommends including libjson in your project directly (per the README).
+As such, these files are intended for testing purposes only. libjson works in QNX with no modifications, and can be found here to include as a submodule in your project: https://github.com/vincenthz/libjson
+
+Instructions for compiling and running tests are listed below.
+
+# Compiling libjson tests for QNX SDP 7.1/8.0
+If you wish to compile in our Docker container, make sure Docker is installed: Requires Docker: https://docs.docker.com/engine/install/
+
+
+1. Make a new workspace or navigate to an existing one
+```bash
+mkdir libjson_wksp && cd libjson_wksp
+```
+
+2. Clone the `libjson` and `build-files` repos
+```bash
+#Pick one:
+#Via HTTPS
+git clone https://github.com/qnx-ports/build-files.git
+git clone https://github.com/vincenthz/libjson.git
+
+#Via SSH
+git clone git@github.com:qnx-ports/build-files.git 
+git clone git@github.com:vincenthz/libjson.git
+```
+
+3. *Optional* Set up the Docker Container
+```bash
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+#Navigate back to your workspace
+#->The container will put you back in your home directory
+cd <path-to-your-workspace>
+```
+
+4. Source your SDP
+```bash
+#QNX 8.0 will be in the directory ~/qnx800/
+#QNX 7.1 will be in the directory ~/qnx710/
+source ~/qnx800/qnxsdp-env.sh
+```
+
+5. Build `libjson` tests & shared objects from your workspace
+```bash
+QNX_PROJECT_ROOT="$(pwd)/libjson" make -C build-files/ports/libjson install -j4
+```
+
+# Installation & Running Tests
+1. Installation
+```bash
+# Set up environment variables for installation
+# These are required for ssh. Please set them based on your QNX target device
+TARGET_IP=<IP-of-your-target>
+TARGET_USER=<user-you-have-credentials-for>
+
+# Set up directories
+ssh $TARGET_USER@$TARGET_IP_ADDRESS "mkdir -p /data/home/$TARGET_USER/libjson/lib"
+
+# Install Test Setup
+#->Change aarch64le to match your architecture (i.e. x86_64, etc)
+scp -r $QNX_TARGET/aarch64le/usr/local/libjson_tests/* $TARGET_USER@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER/libjson
+
+# OPTIONAL: Installed shared objects
+#->These are NOT required for tests, as they are not linked per the recommendation of the libjson authors.
+scp $QNX_TARGET/aarch64le/usr/lib/libjson.so* $TARGET_USER@$TARGET_IP_ADDRESS:/data/home/$TARGET_USER/libjson/lib
+```
+
+2. Running Tests
+```bash
+# Navigate to where tests were installed
+cd ~/libjson/test
+
+# Grant permissions and run tests
+chmod 764 runtest
+./runtest
+```

--- a/ports/libjson/README.md
+++ b/ports/libjson/README.md
@@ -29,7 +29,14 @@ git clone git@github.com:qnx-ports/build-files.git
 git clone git@github.com:vincenthz/libjson.git
 ```
 
-3. *Optional* Set up the Docker Container
+3. *Optional* Checkout preferred commit. Building libjson is only tested on commit `a63d882`, version 1.0.0. While this script will generate correctly versioned .so files for any similar libjson distribution, functionality has not been tested for any other version.
+```bash
+cd libjson
+git checkout a63d882
+cd ..
+```
+
+4. *Optional* Set up the Docker Container
 ```bash
 cd build-files/docker
 ./docker-build-qnx-image.sh
@@ -40,14 +47,14 @@ cd build-files/docker
 cd <path-to-your-workspace>
 ```
 
-4. Source your SDP
+5. Source your SDP
 ```bash
 #QNX 8.0 will be in the directory ~/qnx800/
 #QNX 7.1 will be in the directory ~/qnx710/
 source ~/qnx800/qnxsdp-env.sh
 ```
 
-5. Build `libjson` tests & shared objects from your workspace
+6. Build `libjson` tests & shared objects from your workspace
 ```bash
 QNX_PROJECT_ROOT="$(pwd)/libjson" make -C build-files/ports/libjson install -j4
 ```

--- a/ports/libjson/common.mk
+++ b/ports/libjson/common.mk
@@ -31,8 +31,13 @@ CFLAGS += $(FLAGS)
 
 include $(MKFILES_ROOT)/qtargets.mk
 
+PREFIX ?= /usr/local
+
 CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
-             -DCMAKE_INSTALL_PREFIX=$(libjson_INSTALL_ROOT)/$(CPUVARDIR)/usr \
+             -DCMAKE_INSTALL_PREFIX=$(PREFIX) \
+             -DCMAKE_INSTALL_LIBDIR=$(libjson_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib \
+             -DCMAKE_INSTALL_BINDIR=$(libjson_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/bin \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(libjson_INSTALL_ROOT)/$(PREFIX)/include \
              -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
              -DCMAKE_SYSTEM_PROCESSOR=$(CPUVARDIR) \
              -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \

--- a/ports/libjson/common.mk
+++ b/ports/libjson/common.mk
@@ -53,6 +53,7 @@ ifndef NO_TARGET_OVERRIDE
 libjson_all:
 	@mkdir -p build
 	@cp ../CMakeLists.txt $(QNX_PROJECT_ROOT)/
+	@../get-version.sh
 	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)/
 	@cd build && make $(MAKE_ARGS) all
 

--- a/ports/libjson/common.mk
+++ b/ports/libjson/common.mk
@@ -1,0 +1,63 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+NAME=libjson
+
+DIST_BASE=$(PRODUCT_ROOT)/../../../libjson
+
+ifdef QNX_PROJECT_ROOT
+DIST_BASE=$(QNX_PROJECT_ROOT)
+endif
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+libjson_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#set the following to FALSE if generating .pinfo files is causing problems
+GENERATE_PINFO_FILES ?= TRUE
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = all
+.PHONY: libjson_all install clean
+
+CFLAGS += $(FLAGS)
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(libjson_INSTALL_ROOT)/$(CPUVARDIR)/usr \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DCMAKE_SYSTEM_PROCESSOR=$(CPUVARDIR) \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+             -DCPU=$(CPU)
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+ifndef NO_TARGET_OVERRIDE
+libjson_all:
+	@mkdir -p build
+	@cp ../CMakeLists.txt $(QNX_PROJECT_ROOT)/
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)/
+	@cd build && make $(MAKE_ARGS) all
+
+install: libjson_all
+	@echo Installing...
+	@cd build && make $(MAKE_ARGS) install
+	@echo Done Installing.
+
+clean iclean spotless:
+	rm -rf build
+
+uninstall:
+endif

--- a/ports/libjson/get-version.sh
+++ b/ports/libjson/get-version.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+echo "Finding Versions..."
+MAJOR=$(grep "MAJOR = * " $QNX_PROJECT_ROOT/Makefile | sed 's/MAJOR = //g' | sed 's/ //g')
+MINOR=$(grep "MINOR = * " $QNX_PROJECT_ROOT/Makefile | sed 's/MINOR = //g' | sed 's/ //g')
+MICRO=$(grep "MICRO = * " $QNX_PROJECT_ROOT/Makefile | sed 's/MICRO = //g' | sed 's/ //g')
+
+echo "Setting CMakeLists.txt..."
+sed -i 's/%MAJOR%/'"${MAJOR}"'/g' $QNX_PROJECT_ROOT/CMakeLists.txt
+sed -i 's/%MINOR%/'"${MINOR}"'/g' $QNX_PROJECT_ROOT/CMakeLists.txt
+sed -i 's/%MICRO%/'"${MICRO}"'/g' $QNX_PROJECT_ROOT/CMakeLists.txt

--- a/ports/libjson/nto-aarch64-le/Makefile
+++ b/ports/libjson/nto-aarch64-le/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/libjson/nto-x86_64-o/Makefile
+++ b/ports/libjson/nto-x86_64-o/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/libjson/qnx.nto.toolchain.cmake
+++ b/ports/libjson/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CPU}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CPU}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} -std=gnu++11 ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")


### PR DESCRIPTION
This was a stange one, as the author is against building shared objects from libjson and will not upstream any large build changes, as they wish to have libjson directly included (i.e. copy pasted) into projects. There is also no code changes and thus no need for upstreaming.

README has been refined a lot from my normal template. Custom CMakeLists.txt was required.
Built and tested on 7.1 and 8.0.