### PR TITLE
Updated: memory to reference upstream

### DIFF
--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout memory
       uses: actions/checkout@v4
       with:
-        repository: qnx-ports/memory
+        repository: foonathan/memory
         path: memory
 
     - name: Login to GitHub Container Registry
@@ -45,7 +45,7 @@ jobs:
       run: |
         docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
 
-    - name: Build memory
+    - name: Build memory 016c9fb
       uses: addnab/docker-run-action@v3
       with:
         image: ghcr.io/qnx-ports/sdp800-build-env:latest
@@ -53,5 +53,8 @@ jobs:
         shell: bash
         run: |
           source ~/qnx/800/qnxsdp-env.sh
+          cd ~/workspace
+          cd memory
+          git checkout 016c9fb
           cd ~/workspace
           QNX_PROJECT_ROOT="$(pwd)/memory" make -C build-files/ports/memory install

--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
 
-    - name: Build memory v0.7-3
+    - name: Build memory v0.7-3 (tag checkout does not work)
       uses: addnab/docker-run-action@v3
       with:
         image: ghcr.io/qnx-ports/sdp800-build-env:latest
@@ -55,7 +55,7 @@ jobs:
           source ~/qnx/800/qnxsdp-env.sh
           cd ~/workspace
           cd memory
-          git checkout v0.7-3
+          git checkout 0f07757
           cd ~/workspace
           patch memory/test/CMakeLists.txt < build-files/ports/memory/memory_0.7-3_patch.patch
           QNX_PROJECT_ROOT="$(pwd)/memory" make -C build-files/ports/memory install

--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
 
-    - name: Build memory 016c9fb
+    - name: Build memory v0.7-3
       uses: addnab/docker-run-action@v3
       with:
         image: ghcr.io/qnx-ports/sdp800-build-env:latest
@@ -55,6 +55,7 @@ jobs:
           source ~/qnx/800/qnxsdp-env.sh
           cd ~/workspace
           cd memory
-          git checkout 016c9fb
+          git checkout v0.7-3
           cd ~/workspace
+          patch memory/test/CMakeLists.txt < build-files/ports/memory/memory_0.7-3_patch.patch
           QNX_PROJECT_ROOT="$(pwd)/memory" make -C build-files/ports/memory install

--- a/ports/memory/README.md
+++ b/ports/memory/README.md
@@ -27,23 +27,33 @@ git clone git@github.com:qnx-ports/build-files.git
 git clone git@github.com:qnx-ports/memory.git
 ```
 
-3. Build the Docker image and create a container
+3. **Optional** Checkout tested commit: Checkout Commit `016c9fb` from foonathan memory, which is tested by us.
+```bash
+cd memory
+git checkout 016c9fb
+cd ..
+```
+
+4. **Optional** Build the Docker image and create a container
 ```bash
 cd build-files/docker
 ./docker-build-qnx-image.sh
 ./docker-create-container.sh
+
+#Docker will put you in your home directory.
+cd <path-to-your-workspace>
 ```
 
-4. Source your SDP (Installed from QNX Software Center)
+5. Source your SDP (Installed from QNX Software Center)
 ```bash
 #QNX 8.0 will be in the directory ~/qnx800/
 #QNX 7.1 will be in the directory ~/qnx710/
 source ~/qnx800/qnxsdp-env.sh
 ```
 
-5. Build the project in your workspace from Step 1
+6. Build the project in your workspace from Step 1
 ```bash
-QNX_PROJECT_ROOT="$(PWD)/memory" make -C build-files/ports/memory install -j4
+QNX_PROJECT_ROOT="$PWD/memory" make -C build-files/ports/memory install -j4
 ```
 
 **NOTE**: Before rebuilding, you may need to delete the `/build` subdirectories and their contents in `build-files/ports/memory/nto/aarch64/le` and `build-files/ports/memory/nto/x86_64/so`. This MUST be done when changing from SDP 7.1 to 8 or vice versa, as it will link against the wrong shared objects and not show an error until testing.

--- a/ports/memory/README.md
+++ b/ports/memory/README.md
@@ -20,18 +20,21 @@ mkdir memory_wksp && cd memory_wksp
 #Pick one:
 #Via HTTPS
 git clone https://github.com/qnx-ports/build-files.git
-git clone https://github.com/qnx-ports/memory.git
+git clone https://github.com/foonathan/memory.git
 
 #Via SSH
 git clone git@github.com:qnx-ports/build-files.git
-git clone git@github.com:qnx-ports/memory.git
+git clone git@github.com:foonathan/memory.git
 ```
 
-3. **Optional** Checkout tested commit: Checkout Commit `016c9fb` from foonathan memory, which is tested by us.
+3. **Optional** Checkout tested commit: Checkout Commit `v0.7-3` from foonathan memory, which is tested by us and is the only version on which the test patch will work.
 ```bash
+#Checkout the correct tag
 cd memory
-git checkout 016c9fb
+git checkout v0.7-3
 cd ..
+#Apply the desired patch
+patch memory/test/CMakeLists.txt < build-files/ports/memory/memory_0.7-3_patch.patch
 ```
 
 4. **Optional** Build the Docker image and create a container

--- a/ports/memory/common.mk
+++ b/ports/memory/common.mk
@@ -26,7 +26,7 @@ ALL_DEPENDENCIES = memory_all
 .PHONY: memory_all install check clean
 
 CFLAGS += $(FLAGS)
-LDFLAGS += -Wl,--build-id=md5
+LDFLAGS += -Wl,--build-id=md5 -lc++ -lm
 
 define PINFO
 endef
@@ -51,16 +51,12 @@ MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
 ifndef NO_TARGET_OVERRIDE
 memory_all:
 	@mkdir -p build
-	@if ! grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then echo "if(QNX)" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "install(TARGETS foonathan_memory_test DESTINATION bin/) #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "endif() #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; fi
 	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)/
 	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
-	@if grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then sed -i "/QNX/d" $(QNX_PROJECT_ROOT)/test/CMakeLists.txt ; fi
 
 install check: memory_all
 	@echo Installing...
-	@if ! grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then echo "if(QNX)" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "install(TARGETS foonathan_memory_test DESTINATION bin/) #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "endif() #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; fi
 	@cd build && make VERBOSE=1 install all $(MAKE_ARGS)
-	@if grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then sed -i "/QNX/d" $(QNX_PROJECT_ROOT)/test/CMakeLists.txt ; fi
 	@echo Done.
 
 clean iclean spotless:

--- a/ports/memory/common.mk
+++ b/ports/memory/common.mk
@@ -51,12 +51,16 @@ MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
 ifndef NO_TARGET_OVERRIDE
 memory_all:
 	@mkdir -p build
+	@if ! grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then echo "if(QNX)" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "install(TARGETS foonathan_memory_test DESTINATION bin/) #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "endif() #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; fi
 	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)/
 	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+	@if grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then sed -i "/QNX/d" $(QNX_PROJECT_ROOT)/test/CMakeLists.txt ; fi
 
 install check: memory_all
 	@echo Installing...
+	@if ! grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then echo "if(QNX)" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "install(TARGETS foonathan_memory_test DESTINATION bin/) #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; echo "endif() #QNX" >> $(QNX_PROJECT_ROOT)/test/CMakeLists.txt; fi
 	@cd build && make VERBOSE=1 install all $(MAKE_ARGS)
+	@if grep -q QNX "$(QNX_PROJECT_ROOT)/test/CMakeLists.txt" ; then sed -i "/QNX/d" $(QNX_PROJECT_ROOT)/test/CMakeLists.txt ; fi
 	@echo Done.
 
 clean iclean spotless:

--- a/ports/memory/memory_0.7-3_patch.patch
+++ b/ports/memory/memory_0.7-3_patch.patch
@@ -1,0 +1,9 @@
+--- memory_orig/test/CMakeLists.txt	2024-12-18 10:40:23.467727679 -0500
++++ memory/test/CMakeLists.txt	2024-12-18 10:42:23.447750033 -0500
+@@ -44,3 +44,6 @@
+ 
+ add_test(NAME test COMMAND foonathan_memory_test)
+ 
++if(QNX)
++    install(TARGETS foonathan_memory_test DESTINATION bin/) 
++endif()


### PR DESCRIPTION
memory had virtually no changes; only thing was a one line difference installing tests in tests/CMakeLists.txt

Updated to depend on upstream and add that line manually.