### PR TITLE
build instructions for weston

### DIFF
--- a/ports/weston/README.md
+++ b/ports/weston/README.md
@@ -105,41 +105,60 @@ OSLIST=nto make -C qnx/build install JLEVEL=4 install
 ```
 
 # Run weston examples on the target
-
+Path where libraries are stored are crucial to running weston smoothly. If you would like to change the pathing feel free to modify config files in weston/qnx/build/nto/config.h
 ```bash
-TARGET_HOST=<target-ip-address-or-hostname>
+# Run script to tranfer libraries and executbles to the target
+cd ~/qnx_workspace/build-files/ports/weston/scripts
+./transfer.sh
 
-# Path where libraries are stored are crucial to running weston smoothly
-# If you would like to change the pathing feel free to modify config files in weston/qnx/build/nto/config.h
-
-# Transfer weston libraries to the target
-scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/libweston* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/weston qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp -r ~/qnx800/target/qnx/aarch64le/usr/libexec qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-
-# Transfer weston executables to the target
-scp ~/qnx800/target/qnx/aarch64le/usr/sbin/weston qnxuser@$TARGET_HOST:/data/home/qnxuser/bin
-scp ~/qnx800/target/qnx/aarch64le/usr/bin/weston-* qnxuser@$TARGET_HOST:/data/home/qnxuser/bin
-
-# Transfer weston data to the target
-scp -r ~/qnx800/target/qnx/usr/share/weston qnxuser@$TARGET_HOST:/data/home/qnxuser/
-scp -r ~/qnx800/target/qnx/etc/xdg qnxuser@$TARGET_HOST:/data/home/qnxuser
-
-# Transfer wayland libraries to the target
-scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/libwayland* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-
-# Transfer dependacy libraries to the target
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/libmemstream* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/libpixman* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/libepoll* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/libtimerfd* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/libsignalfd* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/libeventfd* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-
-# Transfer xkbcommon dependancy
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/libxkbcommon* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp -r ~/qnx800/target/qnx/usr/share/xkb qnxuser@$TARGET_HOST:/data/home/qnxuser/
+#Example inputs
+#Enter the QNX800 folder directory path (e.g., ~/qnx800): /home/flionardo/qnx800
+#Enter the target IP address: 107.195.40.66
+#Enter the password for the target user: qnxuser
 ```
+## Structure
+he following assumes that all dependency packages (from SDP) **and** all components built as part of this project are installed to the same location on the host machine. This location is referred to as `$INSTALL_DIR`. Adjust process accordingly if components built from this project are installed elsewhere.
+
+Usually, in the default QNX host machine configuration, `$INSTALL_DIR`=`$QNX_TARGET`. `$PROCESSOR` indicates the target-specific install folder (i.e. aarch64le or x86_64).
+
+Weston:
+- `$INSTALL_DIR`/etc/xdg
+    - --> /etc/xdg
+- `$INSTALL_DIR`/usr/share/weston
+    - --> /system/share/weston
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libweston
+    - --> /data/home/qnxuser/lib/libweston/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/weston
+    - --> /data/home/qnxuser/lib/weston/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/libexec
+    - --> /data/home/qnxuser/lib/libexec
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/bin/weston_tests
+    - --> /data/home/qnxuser/weston_tests
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/bin/weston-*
+    - --> /data/home/qnxuser/bin/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libweston*.so*
+    - --> /data/home/qnxuser/lib/
+
+Wayland:
+- `$INSTALL_DIR`/usr/share/xkb
+    - -->  /usr/share/xkb
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libwayland*.so*
+    - --> /data/home/qnxuser/lib/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libepoll*
+    - --> /data/home/qnxuser/lib/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libtimerfd*
+    - --> /data/home/qnxuser/lib/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libmemstream*
+    - --> /data/home/qnxuser/lib/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libeventfd*
+    - --> /data/home/qnxuser/lib/
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libxkbcommon*
+    - --> /data/home/qnxuser/lib/
+
+Others:
+- `$INSTALL_DIR`/`$PROCESSOR`/usr/lib/libpixman*
+    - --> /data/home/qnxuser/lib/
+
 ```bash
 # Login as root
 # Password is root
@@ -225,17 +244,6 @@ position=X,Y
 ```
 
 # Run weston test on target
-```bash
-# Trasnfer weston test libraries to the target
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/test-plugin.so qnxuser@$TARGET_HOST:/data/home/qnxuser/lib/weston
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/test-ivi-layout.so qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/weston-test-desktop-shell.so qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-
-
-# Transfer test data and executables to the target
-scp -r ~/qnx_workspace/weston/tests/reference qnxuser@$TARGET_HOST:/data/home/qnxuser
-scp ~/qnx800/target/qnx/aarch64le/usr/lib/weston-test-* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
-
 ```bash
 # Login as root
 # Password is root

--- a/ports/weston/README.md
+++ b/ports/weston/README.md
@@ -12,6 +12,11 @@ Presequisites to install Weston:
 # Compile the port for QNX in a Docker container
 
 Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+
+Install meson if you decide not to use docker
+```bash
+sudo apt install meson
+```
 ```bash
 # Create a workspace
 mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
@@ -31,6 +36,9 @@ source ~/qnx800/qnxsdp-env.sh
 ### Build glib
 
 ```bash
+# Change the path in ~/qnx-ports/build-files/resources/meson/$QNX_ARCH/qnx$QNX_VERSION.ini to your qnx_sdp_path
+# This file will be used to build pixman, glib, and cairo
+
 # Clone and build glib for both architecture
 cd ~/qnx_workspace
 git clone https://github.com/qnx-ports/glib.git
@@ -42,7 +50,7 @@ export QNX_VERSION=800
 export QNX_ARCH=aarch64le
 meson setup build-qnx$QNX_VERSION --cross-file ~/qnx_workspace/build-files/resources/$QNX_ARCH/qnx$QNX_VERSION.ini -Dprefix=/usr -Dxattr=false
 meson compile -C build-qnx$QNX_VERSION
-DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${architecture} meson install --no-rebuild -C build-qnx800
+DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${QNX_ARCH} meson install --no-rebuild -C build-qnx800
 ```
 
 ### Build pixman
@@ -62,7 +70,7 @@ export QNX_VERSION=800
 export QNX_ARCH=aarch64le
 meson setup build-qnx$QNX_VERSION --cross-file ~/qnx-ports/build-files/resources/meson/$QNX_ARCH/qnx$QNX_VERSION.ini -Dprefix=/usr -Dopenmp=disabled
 meson compile -C build-qnx$QNX_VERSION
-DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${architecture} meson install --no-rebuild -C build-qnx800
+DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${QNX_ARCH} meson install --no-rebuild -C build-qnx800
 ```
 
 ### Build cairo
@@ -83,14 +91,14 @@ export QNX_VERSION=800
 export QNX_ARCH=aarch64le
 meson setup build-qnx$QNX_VERSION --cross-file ~/qnx-ports/build-files/resources/meson/$QNX_ARCH/qnx$QNX_VERSION.ini -Dprefix=/usr -Dtests=disabled
 meson compile -C build-qnx$QNX_VERSION
-DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${architecture} meson install --no-rebuild -C build-qnx800
+DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${QNX_ARCH} meson install --no-rebuild -C build-qnx800
 ```
 
 ### Build Weston
 
 ```bash
 cd ~/qnx_workspace
-https://github.com/qnx-ports/weston.git
+git clone https://github.com/qnx-ports/weston.git
 cd weston
 git checkout qnx-v11.0.3
 OSLIST=nto make -C qnx/build install JLEVEL=4 install

--- a/ports/weston/README.md
+++ b/ports/weston/README.md
@@ -101,6 +101,9 @@ OSLIST=nto make -C qnx/build install JLEVEL=4 install
 ```bash
 TARGET_HOST=<target-ip-address-or-hostname>
 
+# Path where libraries are stored are crucial to running weston smoothly
+# If you would like to change the pathing feel free to modify config files in weston/qnx/build/nto/config.h
+
 # Transfer weston libraries to the target
 scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/libweston* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
 scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/weston qnxuser@$TARGET_HOST:/data/home/qnxuser/lib

--- a/ports/weston/README.md
+++ b/ports/weston/README.md
@@ -1,0 +1,247 @@
+**NOTE**: QNX ports are only supported from a Linux host operating system
+
+Use `$(nproc)` instead of `4` after `JLEVEL=` and `-j` if you want to use the maximum number of cores to build this project.
+32GB of RAM is recommended for using `JLEVEL=$(nproc)` or `-j$(nproc)`.
+
+Presequisites to install Weston:
+- Install glib
+- Install pixman
+- Install cairo
+- Install QNX SDP 8.0 Wayland/Weston from QNX Software Center
+
+# Compile the port for QNX in a Docker container
+
+Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+```bash
+# Create a workspace
+mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+
+# Build the Docker image and create a container
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+# Now you are in the Docker container
+
+# source qnxsdp-env.sh to build for QNX 8.0
+source ~/qnx800/qnxsdp-env.sh
+```
+
+### Build glib
+
+```bash
+# Clone and build glib for both architecture
+cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/glib.git
+cd glib
+git checkout qnx-2.82.2
+
+# Build it for aarch64le and x86_64 architecrure
+export QNX_VERSION=800
+export QNX_ARCH=aarch64le
+meson setup build-qnx$QNX_VERSION --cross-file ~/qnx_workspace/build-files/resources/$QNX_ARCH/qnx$QNX_VERSION.ini -Dprefix=/usr -Dxattr=false
+meson compile -C build-qnx$QNX_VERSION
+DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${architecture} meson install --no-rebuild -C build-qnx800
+```
+
+### Build pixman
+
+```bash
+# Change the path in ~/qnx-ports/build-files/resources/meson/$QNX_ARCH/qnx$QNX_VERSION.ini to your qnx_sdp_path
+# This file will be used to build pixman, glib, and cairo
+
+# Clone and build pixman for both architecture
+cd ~/qnx_workspace
+git clone https://gitlab.freedesktop.org/pixman/pixman.git
+cd pixman
+git checkout pixman-0.43.4
+
+# Build it for aarch64le and x86_64 architecrure
+export QNX_VERSION=800
+export QNX_ARCH=aarch64le
+meson setup build-qnx$QNX_VERSION --cross-file ~/qnx-ports/build-files/resources/meson/$QNX_ARCH/qnx$QNX_VERSION.ini -Dprefix=/usr -Dopenmp=disabled
+meson compile -C build-qnx$QNX_VERSION
+DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${architecture} meson install --no-rebuild -C build-qnx800
+```
+
+### Build cairo
+
+```bash
+# Change the path in ~/qnx-ports/build-files/resources/meson/$QNX_ARCH/qnx$QNX_VERSION.ini to your qnx_sdp_path
+# This file will be used to build pixman, glib, and cairo
+
+# Clone and build pixman for both architecture
+cd ~/qnx_workspace
+git clone https://gitlab.freedesktop.org/cairo/cairo.git
+cd cairo
+git checkout 1.18.0
+
+# Copy everything from resources/pkgconfig/$SDP_VERSION/$ARCH to your QNX_TARGET's usr/lib/pkgconfig folder
+# Build it for aarch64le and x86_64 architecrure
+export QNX_VERSION=800
+export QNX_ARCH=aarch64le
+meson setup build-qnx$QNX_VERSION --cross-file ~/qnx-ports/build-files/resources/meson/$QNX_ARCH/qnx$QNX_VERSION.ini -Dprefix=/usr -Dtests=disabled
+meson compile -C build-qnx$QNX_VERSION
+DESTDIR=/path/to/qnx$QNX_VERSION/target/qnx/${architecture} meson install --no-rebuild -C build-qnx800
+```
+
+### Build Weston
+
+```bash
+cd ~/qnx_workspace
+https://github.com/qnx-ports/weston.git
+cd weston
+git checkout qnx-v11.0.3
+OSLIST=nto make -C qnx/build install JLEVEL=4 install
+```
+
+# Run weston examples on the target
+
+```bash
+TARGET_HOST=<target-ip-address-or-hostname>
+
+# Transfer weston libraries to the target
+scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/libweston* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/weston qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp -r ~/qnx800/target/qnx/aarch64le/usr/libexec qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+
+# Transfer weston executables to the target
+scp ~/qnx800/target/qnx/aarch64le/usr/sbin/weston qnxuser@$TARGET_HOST:/data/home/qnxuser/bin
+scp ~/qnx800/target/qnx/aarch64le/usr/bin/weston-* qnxuser@$TARGET_HOST:/data/home/qnxuser/bin
+
+# Transfer weston data to the target
+scp -r ~/qnx800/target/qnx/usr/share/weston qnxuser@$TARGET_HOST:/data/home/qnxuser/
+scp -r ~/qnx800/target/qnx/etc/xdg qnxuser@$TARGET_HOST:/data/home/qnxuser
+
+# Transfer wayland libraries to the target
+scp -r ~/qnx800/target/qnx/aarch64le/usr/lib/libwayland* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+
+# Transfer dependacy libraries to the target
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/libmemstream* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/libpixman* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/libepoll* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/libtimerfd* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/libsignalfd* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/libeventfd* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+
+# Transfer xkbcommon dependancy
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/libxkbcommon* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp -r ~/qnx800/target/qnx/usr/share/xkb qnxuser@$TARGET_HOST:/data/home/qnxuser/
+```
+```bash
+# Login as root
+# Password is root
+su
+
+# Create an XDG runtime directory on the target:
+mkdir -p /data/var/run/user/$(id -u ${USER})
+chmod 0700 /data/var/run/user/$(id -u ${USER})
+
+# Export environment variables
+mkdir -p /data/home/qnxuser/tmp
+export TMPDIR=/data/home/qnxuser/tmp
+export XDG_RUNTIME_DIR=/data/var/run/user/$(id -u ${USER})
+export XKB_CONFIG_ROOT=/data/home/qnxuser/xkb
+export LD_LIBRARY_PATH=/data/home/qnxuser/lib/:$LD_LIBRARY_PATH
+export PATH=/data/home/qnxuser/bin:$PATH
+
+# Move data directories to the right path
+mv weston/ /system/share/
+mv xdg/ /etc
+```
+```bash
+# Run weston
+weston --fullscreen
+
+# Run IVI weston
+weston --fullscreen --config weston-ivi.ini
+
+# Run weston client application example
+weston --fullscreen
+
+# Open terminal inside weston and run these client examples
+weston-clickdot &
+weston-smoke &
+```
+
+# QNX Screen backend options
+
+The following subset of command-line and configuration options for Weston are specific to the QNX Screen backend.
+
+## Command-line
+```bash
+QNX Screen backend options:
+    --fullscreen
+
+    --no-input
+            Do not provide any input devices. Used for testing input-less Weston.
+
+    --output-count=N
+            Create N QNX screen windows to emulate the same number of outputs.
+
+    --width=W, --height=H
+            Make the default size of each QNX screen window WxH pixels.
+
+    --position-x=X, --position-y=Y
+            Make the default position of each QNX screen window X,Y
+
+    --scale=N
+            Give all outputs a scale factor of N.
+
+    --display=N
+            Make the default display for each QNX screen window N.
+
+    --egl-display=N
+            Make the default EGL display (GPU) for each QNX screen window N.
+
+    --use-pixman
+            Use the pixman renderer. By default weston will try to use EGL and GLES2 for rendering.
+```
+## Configuration (weston.ini)
+```bash
+name=name
+    QS1       QNX Screen backend, QNX Screen window no.1
+
+mode=mode
+    On the QNX screen backend, it just sets the WIDTHxHEIGHT of the weston window.
+
+display=display
+    The display on which this QNX Screen output window should be placed.
+
+position=X,Y
+    The position where this QNX Screen output window should be placed on the display.
+```
+
+# Run weston test on target
+```bash
+# Trasnfer weston test libraries to the target
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/test-plugin.so qnxuser@$TARGET_HOST:/data/home/qnxuser/lib/weston
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/test-ivi-layout.so qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/weston-test-desktop-shell.so qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+
+
+# Transfer test data and executables to the target
+scp -r ~/qnx_workspace/weston/tests/reference qnxuser@$TARGET_HOST:/data/home/qnxuser
+scp ~/qnx800/target/qnx/aarch64le/usr/lib/weston-test-* qnxuser@$TARGET_HOST:/data/home/qnxuser/lib
+
+```bash
+# Login as root
+# Password is root
+su
+
+# Create an XDG runtime directory on the target:
+mkdir -p /data/var/run/user/$(id -u ${USER})
+chmod 0700 /data/var/run/user/$(id -u ${USER})
+
+# Export environment variables
+mkdir -p /data/home/qnxuser/tmp
+export TMPDIR=/data/home/qnxuser/tmp
+export XDG_RUNTIME_DIR=/data/var/run/user/$(id -u ${USER})
+export XKB_CONFIG_ROOT=/data/home/qnxuser/xkb
+export LD_LIBRARY_PATH=/data/home/qnxuser/lib/:$LD_LIBRARY_PATH
+export PATH=/data/home/qnxuser/bin:$PATH
+
+# Run the test executables
+./zuc-test
+```

--- a/ports/weston/scripts/transfer.sh
+++ b/ports/weston/scripts/transfer.sh
@@ -3,7 +3,7 @@
 # Prompt for QNX800 directory, target IP, and password
 read -p "Enter the QNX800 folder directory path (e.g., ~/qnx800): " QNX_DIR
 read -p "Enter the target IP address: " TARGET_HOST
-read -sp "Enter the password for the target user: " TARGET_PASSWORD
+read -p "Enter the password for the target user: " TARGET_PASSWORD
 echo ""
 
 # Check if sshpass is installed
@@ -25,11 +25,17 @@ TARGET_BASE="/data/home/$TARGET_USER"
 # Ensure necessary target directories exist on the target system
 sshpass -p "$TARGET_PASSWORD" ssh "$TARGET_USER@$TARGET_HOST" "mkdir -p $TARGET_BASE/lib $TARGET_BASE/bin"
 
-# Transfer libraries to the target
-echo "Transferring libraries..."
+# Transfer weston libraries to the target
+echo "Transferring weston libraries..."
 sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/aarch64le/usr/lib/libweston* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
 sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/aarch64le/usr/lib/weston "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
 sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/aarch64le/usr/libexec "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+
+# Transfer weston test libraries to the target
+echo "Transferring weston test libraries..."
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/lib/test-plugin.so "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib/weston"
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/lib/test-ivi-layout.so "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/lib/weston-test-desktop-shell.so "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
 
 # Transfer weston executables to the target
 echo "Transferring weston executables..."
@@ -55,5 +61,11 @@ done
 echo "Transferring xkbcommon dependency..."
 sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/lib/libxkbcommon* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
 sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/usr/share/xkb "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/"
+
+# Transfer test data and executables to the target
+echo "Transferring test data and executables..."
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/qnx_workspace/weston/tests/reference "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/"
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/lib/weston-test-* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/bin/weston_tests "$TARGET_USER@$TARGET_HOST:$TARGET_BASE"
 
 echo "All transfers completed successfully!"

--- a/ports/weston/scripts/transfer.sh
+++ b/ports/weston/scripts/transfer.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Prompt for QNX800 directory, target IP, and password
+read -p "Enter the QNX800 folder directory path (e.g., ~/qnx800): " QNX_DIR
+read -p "Enter the target IP address: " TARGET_HOST
+read -sp "Enter the password for the target user: " TARGET_PASSWORD
+echo ""
+
+# Check if sshpass is installed
+if ! command -v sshpass &> /dev/null; then
+    echo "Error: sshpass is not installed. Please install it using: sudo apt install sshpass"
+    exit 1
+fi
+
+# Check if the directory exists
+if [ ! -d "$QNX_DIR" ]; then
+    echo "Error: The directory $QNX_DIR does not exist."
+    exit 1
+fi
+
+# Define the target user and base path
+TARGET_USER="qnxuser"
+TARGET_BASE="/data/home/$TARGET_USER"
+
+# Ensure necessary target directories exist on the target system
+sshpass -p "$TARGET_PASSWORD" ssh "$TARGET_USER@$TARGET_HOST" "mkdir -p $TARGET_BASE/lib $TARGET_BASE/bin"
+
+# Transfer libraries to the target
+echo "Transferring libraries..."
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/aarch64le/usr/lib/libweston* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/aarch64le/usr/lib/weston "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/aarch64le/usr/libexec "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+
+# Transfer weston executables to the target
+echo "Transferring weston executables..."
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/sbin/weston "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/bin"
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/bin/weston-* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/bin"
+
+# Transfer weston data to the target
+echo "Transferring weston data..."
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/usr/share/weston "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/"
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/etc/xdg "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/"
+
+# Transfer wayland libraries to the target
+echo "Transferring wayland libraries..."
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/aarch64le/usr/lib/libwayland* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+
+# Transfer dependency libraries to the target
+echo "Transferring dependency libraries..."
+for lib in libmemstream libpixman libepoll libtimerfd libsignalfd libeventfd; do
+    sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/lib/${lib}* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+done
+
+# Transfer xkbcommon dependency
+echo "Transferring xkbcommon dependency..."
+sshpass -p "$TARGET_PASSWORD" scp $QNX_DIR/target/qnx/aarch64le/usr/lib/libxkbcommon* "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/lib"
+sshpass -p "$TARGET_PASSWORD" scp -r $QNX_DIR/target/qnx/usr/share/xkb "$TARGET_USER@$TARGET_HOST:$TARGET_BASE/"
+
+echo "All transfers completed successfully!"


### PR DESCRIPTION
Currently weston has a QNX software center dependancy on QNX SDP 8.0 Wayland/Weston, so making a github workflow for weston will not work. will look into making it free of software center dependancy and will adjust the readme file accordingly.

its a fairly long process to get weston to run. Need feedback regarding the instructions in the readme file to ensure a smooth install process of weston

Testing results from previous porter:
Most tests pass, however there are a few errors:

- GL-renderer does not work with headless backend, outputs error: "EGL does not support surface less platform.”
- bad-buffer: create a bad buffer that will crash compositor, attach it to a surface, expect an error. The expected error is indeed returned, but the interface is wrong.
- color-manager: Smoke test for color-management=true. No lcms.so.
- color-metadata-errors: create mock weston.ini or color manager metadata that are wrong, verify that Weston can detect the errors. One test case fails because the buffer created by memstream contains unexpected random characters.
- some plugin tests, although pass, output “failed to create display” error. This seems to have something to do with the default test shell SHELL_DESKTOP. If the shell is changed to SHELL_TEST_DESKTOP or SHELL_IVI then it does not output this error message.