### PR TITLE
Glib update

### DIFF
--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -82,6 +82,12 @@ jobs:
         repository: GNOME/glib
         path: glib
 
+    - name: Checkout glib
+      uses: actions/checkout@v4
+      with:
+        repository: mesonbuild/meson
+        path: meson
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
@@ -107,6 +113,6 @@ jobs:
           mkdir -p output
           cd glib
           git apply --whitespace=nowarn ../build-files/ports/glib/001-meson-build.patch
-          /usr/local/qnx/env/bin/meson setup build-qnx$QNX_VERSION --cross-file ../build-files/resources/meson/aarch64le/workflows/qnx800.ini -Dprefix=/usr -Dxattr=false
-          /usr/local/qnx/env/bin/meson compile -C build-qnx$QNX_VERSION
-          DESTDIR=/home/runner/workspace/output /usr/local/qnx/env/bin/meson install --no-rebuild -C build-qnx$QNX_VERSION
+          ../meson/meson.py setup build-qnx$QNX_VERSION --cross-file ../build-files/resources/meson/aarch64le/workflows/qnx800.ini -Dprefix=/usr -Dxattr=false
+          ../meson/meson.py compile -C build-qnx$QNX_VERSION
+          DESTDIR=/home/runner/workspace/output ../meson/meson.py install --no-rebuild -C build-qnx$QNX_VERSION

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
 
-  build:
+  build-qnx-ports:
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
@@ -60,6 +60,53 @@ jobs:
           export QNX_ARCH=aarch64le
           mkdir -p output
           cd glib
+          /usr/local/qnx/env/bin/meson setup build-qnx$QNX_VERSION --cross-file ../build-files/resources/meson/aarch64le/workflows/qnx800.ini -Dprefix=/usr -Dxattr=false
+          /usr/local/qnx/env/bin/meson compile -C build-qnx$QNX_VERSION
+          DESTDIR=/home/runner/workspace/output /usr/local/qnx/env/bin/meson install --no-rebuild -C build-qnx$QNX_VERSION
+
+  build-glib-main:
+    runs-on: self-hosted
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'glib'))
+    steps:
+    - name: Checkout build-files
+      uses: actions/checkout@v4
+      with:
+        path: build-files
+
+    - name: Checkout glib
+      uses: actions/checkout@v4
+      with:
+        repository: GNOME/glib
+        path: glib
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+
+    - name: Pull build environment
+      run: |
+        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+
+    - name: Build glib
+      uses: addnab/docker-run-action@v3
+      with:
+        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
+        shell: bash
+        run: |
+          source ~/qnx/800/qnxsdp-env.sh
+          cd ~/workspace
+          export QNX_VERSION=800
+          export QNX_ARCH=aarch64le
+          mkdir -p output
+          cd glib
+          git apply --whitespace=nowarn ../build-files/ports/glib/001-meson-build.patch
           /usr/local/qnx/env/bin/meson setup build-qnx$QNX_VERSION --cross-file ../build-files/resources/meson/aarch64le/workflows/qnx800.ini -Dprefix=/usr -Dxattr=false
           /usr/local/qnx/env/bin/meson compile -C build-qnx$QNX_VERSION
           DESTDIR=/home/runner/workspace/output /usr/local/qnx/env/bin/meson install --no-rebuild -C build-qnx$QNX_VERSION

--- a/ports/glib/001-meson-build.patch
+++ b/ports/glib/001-meson-build.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index f453d748c..82d9fcb5d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2268,7 +2268,7 @@ libatomic_test_code = '''
+   }'''
+ atomic_dep = []
+ if cc.links(libatomic_test_code, args : '-latomic', name : 'check for -latomic')
+-  atomic_dep = cc.find_library('atomic')
++  atomic_dep = cc.find_library('atomic', required: false)
+ endif
+ 
+ # First check in libc, fallback to libintl, and as last chance build

--- a/ports/glib/README.md
+++ b/ports/glib/README.md
@@ -9,7 +9,7 @@ Current these versions are tested:
 See test reports in `tests/`.
 
 ## GTK compatibility
-If you decide to use GTK on QNX, you should consider installing glib from [GTK repo](https://github.com/qnx-ports/build-files/tree/main/ports/gtk) rather than saprately form here. This glib port is not throughly tested with GTK and unepxected behaviours might occur.
+If you decide to use GTK on QNX, you should consider installing glib from [GTK repo](https://github.com/qnx-ports/build-files/tree/main/ports/gtk) rather than saparately form here. This glib port is not throughly tested with GTK and unepxected behaviours might occur.
 
 ## Compile Glib for SDP 7.1/8.0 on a Linux host
 You'll need the patched version of glib for QNX, available at https://github.com/qnx-ports/glib . For QNX 7.0.0 use the `qnx700-$VER` branch. For QNX 7.1.0 and 8.0.0, simply use `qnx-$VER` branch.

--- a/ports/glib/README.md
+++ b/ports/glib/README.md
@@ -2,14 +2,14 @@
 
 **NOTE**: currently only aarch64le is supported.
 
-## GTK compatibility
-If you decide to use GTK on QNX, you should consider installing glib from [GTK repo](https://github.com/qnx-ports/build-files/tree/main/ports/gtk) rather than saprately form here. This glib port is not throughly tested with GTK and unepxected behaviours might occur.
-
 Current these versions are tested:
 + `glib/main` (Recommanded)
 + `qnx-ports/qnx-2.82.0`
 
 See test reports in `tests/`.
+
+## GTK compatibility
+If you decide to use GTK on QNX, you should consider installing glib from [GTK repo](https://github.com/qnx-ports/build-files/tree/main/ports/gtk) rather than saprately form here. This glib port is not throughly tested with GTK and unepxected behaviours might occur.
 
 ## Compile Glib for SDP 7.1/8.0 on a Linux host
 You'll need the patched version of glib for QNX, available at https://github.com/qnx-ports/glib . For QNX 7.0.0 use the `qnx700-$VER` branch. For QNX 7.1.0 and 8.0.0, simply use `qnx-$VER` branch.

--- a/ports/glib/README.md
+++ b/ports/glib/README.md
@@ -28,7 +28,7 @@ export QNX_ARCH=aarch64le
 cd ~/workspace
 # Using QNX's fork of glib
 git clone https://github.com/qnx-ports/glib.git
-# Or using gib/main and and obtain the patch build-files repo
+# Or using gib/main
 git clone https://gitlab.gnome.org/GNOME/glib.git
 
 # Navigate into ./glib

--- a/ports/glib/README.md
+++ b/ports/glib/README.md
@@ -14,7 +14,7 @@ If you decide to use GTK on QNX, you should consider installing glib from [GTK r
 ## Compile Glib for SDP 7.1/8.0 on a Linux host
 You'll need the patched version of glib for QNX, available at https://github.com/qnx-ports/glib . For QNX 7.0.0 use the `qnx700-$VER` branch. For QNX 7.1.0 and 8.0.0, simply use `qnx-$VER` branch.
 
-If you decide to compile from the `glib/main`, you will also need to apply patch to `meson.build`. `glib/main` provides some additional file system mounting features offer by `gio` compared to `qnx-ports/qnx-2.82.0`
+If you decide to compile from the `glib/main`, you will also need to apply patch to `meson.build`. `glib/main` provides some additional file system mounting features offer by `gio` compared to `qnx-ports/qnx-2.82.0`. Additionally, meson 1.4 and above is required.
 
 To build, first enable your SDP, and then use the cross compile config file available inside this repo under `/resources/meson`, then use meson setup to generate build script, meson compile to do the actual compiling, and finally meson install to install it to your SDP (as dependency for other project or development), or an empty folder so you can transfer it to an actual QNX system.
 

--- a/ports/glib/README.md
+++ b/ports/glib/README.md
@@ -2,13 +2,19 @@
 
 **NOTE**: currently only aarch64le is supported.
 
+## GTK compatibility
+If you decide to use GTK on QNX, you should consider installing glib from [GTK repo](https://github.com/qnx-ports/build-files/tree/main/ports/gtk) rather than saprately form here. This glib port is not throughly tested with GTK and unepxected behaviours might occur.
+
 Current these versions are tested:
-+ 2.82.0
++ `glib/main` (Recommanded)
++ `qnx-ports/qnx-2.82.0`
 
 See test reports in `tests/`.
 
 ## Compile Glib for SDP 7.1/8.0 on a Linux host
 You'll need the patched version of glib for QNX, available at https://github.com/qnx-ports/glib . For QNX 7.0.0 use the `qnx700-$VER` branch. For QNX 7.1.0 and 8.0.0, simply use `qnx-$VER` branch.
+
+If you decide to compile from the `glib/main`, you will also need to apply patch to `meson.build`. `glib/main` provides some additional file system mounting features offer by `gio` compared to `qnx-ports/qnx-2.82.0`
 
 To build, first enable your SDP, and then use the cross compile config file available inside this repo under `/resources/meson`, then use meson setup to generate build script, meson compile to do the actual compiling, and finally meson install to install it to your SDP (as dependency for other project or development), or an empty folder so you can transfer it to an actual QNX system.
 
@@ -22,9 +28,14 @@ export QNX_ARCH=aarch64le
 cd ~/workspace
 # Using QNX's fork of glib
 git clone https://github.com/qnx-ports/glib.git
+# Or using gib/main and and obtain the patch build-files repo
+git clone https://gitlab.gnome.org/GNOME/glib.git
+
+# Navigate into ./glib
 cd glib/
-# For QNX 7.1.0+, use the generic branch
-git checkout qnx-2.82.2
+# patch meson.build if using glib/main
+git apply --whitespace=nowarn ../build-files/ports/glib/001-meson-build.patch
+
 # Generate build script
 meson setup build-qnx$QNX_VERSION --cross-file ~/workspace/build-files/resources/$QNX_ARCH/qnx$QNX_VERSION.ini -Dprefix=/usr -Dxattr=false
 meson compile -C build-qnx$QNX_VERSION
@@ -47,7 +58,10 @@ export QNX_ARCH=aarch64le
 cd ~/workspace
 # Using QNX's fork of glib
 git clone https://github.com/qnx-ports/glib.git
+
+# Navigate into ./glib
 cd glib/
+
 # For QNX 7.0.0, use a special branch for it
 git checkout qnx700-2.82.2
 # Generate build script. Notice the prefix here is /system


### PR DESCRIPTION
...
Add optional repo from glib's main branch, it has more features than what we forked but does not work with 7.1 and require extra patch