### PR TITLE
Catch2 reverted modification of amalgamated distribution files

### DIFF
--- a/.github/workflows/Catch2.yml
+++ b/.github/workflows/Catch2.yml
@@ -55,4 +55,7 @@ jobs:
         run: |
           source ~/qnx/800/qnxsdp-env.sh
           cd ~/workspace
+          cd Catch2
+          ./tools/scripts/generateAmalgamatedFiles.py
+          cd -
           make -C build-files/ports/Catch2 install

--- a/ports/Catch2/README.md
+++ b/ports/Catch2/README.md
@@ -9,6 +9,11 @@ git clone https://github.com/qnx-ports/build-files.git
 git clone https://github.com/qnx-ports/Catch2.git
 ```
 
+# Regenerate the amalgamated distribution (some tests are built against it)
+```bash
+./tools/scripts/generateAmalgamatedFiles.py
+```
+
 # Setup a Docker container
 
 Pre-requisite:


### PR DESCRIPTION
setup additional step for generation source files before building.