### PR TITLE
glib: update with pcre2, libffi and zlib

### DIFF
--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -76,6 +76,27 @@ jobs:
       with:
         path: build-files
 
+    - name: Checkout zlib
+      uses: actions/checkout@v4
+      with:
+        repository: madler/zlib
+        path: zlib
+        ref: v1.3.1
+
+    - name: Checkout pcre2
+      uses: actions/checkout@v4
+      with:
+        repository: PCRE2Project/pcre2
+        path: pcre2
+        ref: pcre2-10.45
+
+    - name: Checkout libffi
+      uses: actions/checkout@v4
+      with:
+        repository: libffi/libffi
+        path: libffi
+        ref: v3.2.1
+
     - name: Checkout glib
       uses: actions/checkout@v4
       with:
@@ -108,4 +129,7 @@ jobs:
         run: |
           source ~/qnx/800/qnxsdp-env.sh
           cd ~/workspace
+          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/zlib" make -C build-files/ports/zlib install
+          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi install
+          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/pcre2" make -C build-files/ports/pcre2 install
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/glib" make -C build-files/ports/glib install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -139,7 +139,5 @@ jobs:
             source ~/qnx/710/qnxsdp-env.sh
           fi
           cd ~/workspace
-          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/zlib" make -C build-files/ports/zlib install
-          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi install
-          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/pcre2" make -C build-files/ports/pcre2 install
+          ./build-files/ports/glib/install_all.sh
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/glib" make -C build-files/ports/glib install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -45,22 +45,29 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ${{ matrix.qnx_env }}
 
     - name: Build glib
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ${{ matrix.qnx_env }}
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
-          source ~/qnx/800/qnxsdp-env.sh
+          if [[ "${{ matrix.qnx_env}}" == "ghcr.io/qnx-ports/sdp800-build-env:latest" ]]; then
+            source ~/qnx/800/qnxsdp-env.sh
+            export QNX_VERSION=800
+            export CROSS_FILE=../build-files/resources/meson/aarch64le/workflows/qnx800.ini
+          else 
+            source ~/qnx/710/qnxsdp-env.sh
+            export QNX_VERSION=710
+            export CROSS_FILE=../build-files/resources/meson/aarch64le/workflows/qnx710.ini
+          fi
           cd ~/workspace
-          export QNX_VERSION=800
           export QNX_ARCH=aarch64le
           mkdir -p output
           cd glib
-          /usr/local/qnx/env/bin/meson setup build-qnx$QNX_VERSION --cross-file ../build-files/resources/meson/aarch64le/workflows/qnx800.ini -Dprefix=/usr -Dxattr=false
+          /usr/local/qnx/env/bin/meson setup build-qnx$QNX_VERSION --cross-file $CROSS_FILE -Dprefix=/usr -Dxattr=false
           /usr/local/qnx/env/bin/meson compile -C build-qnx$QNX_VERSION
           DESTDIR=/home/runner/workspace/output /usr/local/qnx/env/bin/meson install --no-rebuild -C build-qnx$QNX_VERSION
 
@@ -118,16 +125,20 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ${{ matrix.qnx_env }}
 
     - name: Build glib
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ${{ matrix.qnx_env }}
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
-          source ~/qnx/800/qnxsdp-env.sh
+          if [[ "${{ matrix.qnx_env}}" == "ghcr.io/qnx-ports/sdp800-build-env:latest" ]]; then
+            source ~/qnx/800/qnxsdp-env.sh
+          else 
+            source ~/qnx/710/qnxsdp-env.sh
+          fi
           cd ~/workspace
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/zlib" make -C build-files/ports/zlib install
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -18,11 +18,6 @@ on:
 jobs:
 
   build-qnx-ports:
-    strategy:
-      matrix:
-        qnx_env:
-          - ghcr.io/qnx-ports/sdp800-build-env:latest
-          - ghcr.io/qnx-ports/sdp-build-env:latest
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
@@ -50,24 +45,18 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ${{ matrix.qnx_env }}
+        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
 
     - name: Build glib
       uses: addnab/docker-run-action@v3
       with:
-        image: ${{ matrix.qnx_env }}
+        image: ghcr.io/qnx-ports/sdp800-build-env:latest
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
-          if [[ "${{ matrix.qnx_env}}" == "ghcr.io/qnx-ports/sdp800-build-env:latest" ]]; then
-            source ~/qnx/800/qnxsdp-env.sh
-            export QNX_VERSION=800
-            export CROSS_FILE=../build-files/resources/meson/aarch64le/workflows/qnx800.ini
-          else 
-            source ~/qnx/710/qnxsdp-env.sh
-            export QNX_VERSION=710
-            export CROSS_FILE=../build-files/resources/meson/aarch64le/workflows/qnx710.ini
-          fi
+          source ~/qnx/800/qnxsdp-env.sh
+          export QNX_VERSION=800
+          export CROSS_FILE=../build-files/resources/meson/aarch64le/workflows/qnx800.ini
           cd ~/workspace
           export QNX_ARCH=aarch64le
           mkdir -p output

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -119,5 +119,6 @@ jobs:
             source ~/qnx/710/qnxsdp-env.sh
           fi
           cd ~/workspace
-          chmod +x ./build-files/ports/glib/install_all.sh && JLEVEL=$(nproc) ./build-files/ports/glib/install_all.sh
+          chmod +x ./build-files/ports/glib/install_all.sh 
+          JLEVEL=$(nproc) ./build-files/ports/glib/install_all.sh
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/glib" make -C build-files/ports/glib install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
 
-  build:
+  build-qnx-ports:
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
@@ -63,3 +63,49 @@ jobs:
           /usr/local/qnx/env/bin/meson setup build-qnx$QNX_VERSION --cross-file ../build-files/resources/meson/aarch64le/workflows/qnx800.ini -Dprefix=/usr -Dxattr=false
           /usr/local/qnx/env/bin/meson compile -C build-qnx$QNX_VERSION
           DESTDIR=/home/runner/workspace/output /usr/local/qnx/env/bin/meson install --no-rebuild -C build-qnx$QNX_VERSION
+
+  build-glib-main:
+    runs-on: self-hosted
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'glib'))
+    steps:
+    - name: Checkout build-files
+      uses: actions/checkout@v4
+      with:
+        path: build-files
+
+    - name: Checkout glib
+      uses: actions/checkout@v4
+      with:
+        repository: GNOME/glib
+        path: glib
+
+    - name: Checkout glib
+      uses: actions/checkout@v4
+      with:
+        repository: mesonbuild/meson
+        path: meson
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+
+    - name: Pull build environment
+      run: |
+        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+
+    - name: Build glib
+      uses: addnab/docker-run-action@v3
+      with:
+        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
+        shell: bash
+        run: |
+          source ~/qnx/800/qnxsdp-env.sh
+          cd ~/workspace
+          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/glib" make -C build-files/ports/glib install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -82,38 +82,18 @@ jobs:
       with:
         path: build-files
 
-    - name: Checkout zlib
-      uses: actions/checkout@v4
-      with:
-        repository: madler/zlib
-        path: zlib
-        ref: v1.3.1
-
-    - name: Checkout pcre2
-      uses: actions/checkout@v4
-      with:
-        repository: PCRE2Project/pcre2
-        path: pcre2
-        ref: pcre2-10.45
-
-    - name: Checkout libffi
-      uses: actions/checkout@v4
-      with:
-        repository: libffi/libffi
-        path: libffi
-        ref: v3.2.1
-
     - name: Checkout glib
       uses: actions/checkout@v4
       with:
         repository: GNOME/glib
         path: glib
 
-    - name: Checkout glib
+    - name: Checkout meson
       uses: actions/checkout@v4
       with:
         repository: mesonbuild/meson
         path: meson
+        ref: 1.7.0
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
@@ -139,5 +119,5 @@ jobs:
             source ~/qnx/710/qnxsdp-env.sh
           fi
           cd ~/workspace
-          ./build-files/ports/glib/install_all.sh
+          JLEVEL=$(nproc) ./build-files/ports/glib/install_all.sh
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/glib" make -C build-files/ports/glib install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -119,5 +119,5 @@ jobs:
             source ~/qnx/710/qnxsdp-env.sh
           fi
           cd ~/workspace
-          JLEVEL=$(nproc) ./build-files/ports/glib/install_all.sh
+          chmod +x ./build-files/ports/glib/install_all.sh && JLEVEL=$(nproc) ./build-files/ports/glib/install_all.sh
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/glib" make -C build-files/ports/glib install

--- a/.github/workflows/glib.yml
+++ b/.github/workflows/glib.yml
@@ -18,6 +18,11 @@ on:
 jobs:
 
   build-qnx-ports:
+    strategy:
+      matrix:
+        qnx_env:
+          - ghcr.io/qnx-ports/sdp800-build-env:latest
+          - ghcr.io/qnx-ports/sdp-build-env:latest
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
@@ -72,6 +77,11 @@ jobs:
           DESTDIR=/home/runner/workspace/output /usr/local/qnx/env/bin/meson install --no-rebuild -C build-qnx$QNX_VERSION
 
   build-glib-main:
+    strategy:
+      matrix:
+        qnx_env:
+          - ghcr.io/qnx-ports/sdp800-build-env:latest
+          - ghcr.io/qnx-ports/sdp-build-env:latest
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -56,5 +56,5 @@ jobs:
         run: |
           cd workspace
           source ~/qnx/800/qnxsdp-env.sh
-          JLEVEL=12 INSTALL_ROOT=$(pwd)/tmp QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi clean install
+          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi clean install
           

--- a/.github/workflows/libffi.yml
+++ b/.github/workflows/libffi.yml
@@ -18,6 +18,11 @@ on:
 jobs:
 
   build:
+    strategy:
+      matrix:
+        qnx_env:
+          - ghcr.io/qnx-ports/sdp800-build-env:latest
+          - ghcr.io/qnx-ports/sdp-build-env:latest
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
@@ -45,16 +50,19 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
-
+        docker pull ${{ matrix.qnx_env }}
     - name: Build libffi
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ${{ matrix.qnx_env }}
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
+          if [[ "${{ matrix.qnx_env}}" == "ghcr.io/qnx-ports/sdp800-build-env:latest" ]]; then
+            source ~/qnx/800/qnxsdp-env.sh
+          else 
+            source ~/qnx/710/qnxsdp-env.sh
+          fi
           cd workspace
-          source ~/qnx/800/qnxsdp-env.sh
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi clean install
           

--- a/.github/workflows/pcre2.yml
+++ b/.github/workflows/pcre2.yml
@@ -18,6 +18,11 @@ on:
 jobs:
  
   build:
+    strategy:
+      matrix:
+        qnx_env:
+          - ghcr.io/qnx-ports/sdp800-build-env:latest
+          - ghcr.io/qnx-ports/sdp-build-env:latest
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
@@ -45,15 +50,19 @@ jobs:
  
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ${{ matrix.qnx_env }}
  
     - name: Build pcre2
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ${{ matrix.qnx_env }}
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
-          source ~/qnx/800/qnxsdp-env.sh
+          if [[ "${{ matrix.qnx_env}}" == "ghcr.io/qnx-ports/sdp800-build-env:latest" ]]; then
+            source ~/qnx/800/qnxsdp-env.sh
+          else 
+            source ~/qnx/710/qnxsdp-env.sh
+          fi
           cd ~/workspace
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/pcre2" make -C build-files/ports/pcre2 install

--- a/.github/workflows/pcre2.yml
+++ b/.github/workflows/pcre2.yml
@@ -1,60 +1,59 @@
-name: libffi
-
+name: pcre2
+ 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/libffi.yml'
-      - 'ports/libffi/**'
+      - '.github/workflows/pcre2.yml'
+      - 'ports/pcre2/**'
   pull_request:
     branches:
       - main
     paths:
-      - '.github/workflows/libffi.yml'
-      - 'ports/libffi/**'
+      - '.github/workflows/pcre2.yml'
+      - 'ports/pcre2/**'
 
 jobs:
-
+ 
   build:
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'libffi'))
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'pcre2'))
     steps:
     - name: Checkout build-files
       uses: actions/checkout@v4
       with:
         path: build-files
-
-    - name: Checkout libffi
+ 
+    - name: Checkout pcre2
       uses: actions/checkout@v4
       with:
-        repository: libffi/libffi
-        path: libffi
-        ref: v3.2.1
-
+        repository: PCRE2Project/pcre2
+        path: pcre2
+        ref: pcre2-10.45
+ 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{github.actor}}
         password: ${{secrets.GITHUB_TOKEN}}
-
+ 
     - name: Pull build environment
       run: |
         docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
-
-    - name: Build libffi
+ 
+    - name: Build pcre2
       uses: addnab/docker-run-action@v3
       with:
         image: ghcr.io/qnx-ports/sdp800-build-env:latest
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
-          cd workspace
           source ~/qnx/800/qnxsdp-env.sh
-          JLEVEL=12 INSTALL_ROOT=$(pwd)/tmp QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi clean install
-          
+          cd ~/workspace
+          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/pcre2" make -C build-files/ports/pcre2 install

--- a/.github/workflows/zlib.yml
+++ b/.github/workflows/zlib.yml
@@ -1,60 +1,59 @@
-name: libffi
-
+name: zlib
+ 
 on:
   workflow_dispatch:
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/libffi.yml'
-      - 'ports/libffi/**'
+      - '.github/workflows/zlib.yml'
+      - 'ports/zlib/**'
   pull_request:
     branches:
       - main
     paths:
-      - '.github/workflows/libffi.yml'
-      - 'ports/libffi/**'
+      - '.github/workflows/zlib.yml'
+      - 'ports/zlib/**'
 
 jobs:
-
+ 
   build:
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'libffi'))
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'zlib'))
     steps:
     - name: Checkout build-files
       uses: actions/checkout@v4
       with:
         path: build-files
-
-    - name: Checkout libffi
+ 
+    - name: Checkout zlib
       uses: actions/checkout@v4
       with:
-        repository: libffi/libffi
-        path: libffi
-        ref: v3.2.1
-
+        repository: madler/zlib
+        path: zlib
+        ref: v1.3.1
+ 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{github.actor}}
         password: ${{secrets.GITHUB_TOKEN}}
-
+ 
     - name: Pull build environment
       run: |
         docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
-
-    - name: Build libffi
+ 
+    - name: Build zlib
       uses: addnab/docker-run-action@v3
       with:
         image: ghcr.io/qnx-ports/sdp800-build-env:latest
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
-          cd workspace
           source ~/qnx/800/qnxsdp-env.sh
-          JLEVEL=12 INSTALL_ROOT=$(pwd)/tmp QNX_PROJECT_ROOT="$(pwd)/libffi" make -C build-files/ports/libffi clean install
-          
+          cd ~/workspace
+          JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/zlib" make -C build-files/ports/zlib install

--- a/.github/workflows/zlib.yml
+++ b/.github/workflows/zlib.yml
@@ -18,6 +18,11 @@ on:
 jobs:
  
   build:
+    strategy:
+      matrix:
+        qnx_env:
+          - ghcr.io/qnx-ports/sdp800-build-env:latest
+          - ghcr.io/qnx-ports/sdp-build-env:latest
     runs-on: self-hosted
     if: |
       (github.event_name == 'workflow_dispatch') ||
@@ -45,15 +50,19 @@ jobs:
  
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ${{ matrix.qnx_env }}
  
     - name: Build zlib
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ${{ matrix.qnx_env }}
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |
-          source ~/qnx/800/qnxsdp-env.sh
+          if [[ "${{ matrix.qnx_env}}" == "ghcr.io/qnx-ports/sdp800-build-env:latest" ]]; then
+            source ~/qnx/800/qnxsdp-env.sh
+          else 
+            source ~/qnx/710/qnxsdp-env.sh
+          fi
           cd ~/workspace
           JLEVEL=$(nproc) QNX_PROJECT_ROOT="$(pwd)/zlib" make -C build-files/ports/zlib install

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You have two options for building the ports:
 | [opencv](https://github.com/qnx-ports/build-files/blob/main/ports/opencv/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/opencv.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/opencv.yml) |
 | [pandas](https://github.com/qnx-ports/build-files/blob/main/ports/pandas/README.md) | |
 | [pixman](https://github.com/qnx-ports/build-files/blob/main/ports/pixman/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/pixman.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/pixman.yml) |
+| [pcre2](https://github.com/qnx-ports/build-files/blob/main/ports/pcre2/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/pcre2.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/pcre2.yml) |
 | [protobuf](https://github.com/qnx-ports/build-files/blob/main/ports/protobuf/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/protobuf.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/protobuf.yml) |
 | [pytorch](https://github.com/qnx-ports/build-files/blob/main/ports/pytorch/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/pytorch.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/pytorch.yml) |
 | [qt](https://github.com/qnx-ports/build-files/blob/main/ports/qt/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/qt.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/qt.yml) |
@@ -82,8 +83,6 @@ You have two options for building the ports:
 | [tftp-hpa](https://github.com/qnx-ports/build-files/blob/main/ports/tftp-hpa/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/tftp-hpa.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/tftp-hpa.yml) |
 | [tinyxml2](https://github.com/qnx-ports/build-files/blob/main/ports/tinyxml2/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/tinyxml2.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/tinyxml2.yml) |
 | [vsomeip](https://github.com/qnx-ports/build-files/blob/main/ports/vsomeip/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/vsomeip.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/vsomeip.yml) |
-
-
-
+| [zlib](https://github.com/qnx-ports/build-files/blob/main/ports/zlib/README.md) | [![Build](https://github.com/qnx-ports/build-files/actions/workflows/zlib.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/zlib.yml) |
 ---
 	

--- a/ports/glib/.gitignore
+++ b/ports/glib/.gitignore
@@ -1,0 +1,7 @@
+!Makefile
+!nto-aarch64-le/Makefile
+!nto-x86_64-o/Makefile
+nto-aarch64-le/build
+nto-x86_64-o/build
+nto-aarch64-le/qnx_cross.cfg
+nto-x86_64-o/qnx_cross.cfg

--- a/ports/glib/001-skip-detecting-latomic.patch
+++ b/ports/glib/001-skip-detecting-latomic.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index f453d748c..82d9fcb5d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2268,7 +2268,7 @@ libatomic_test_code = '''
+   }'''
+ atomic_dep = []
+ if cc.links(libatomic_test_code, args : '-latomic', name : 'check for -latomic')
+-  atomic_dep = cc.find_library('atomic')
++  atomic_dep = cc.find_library('atomic', required: false)
+ endif
+ 
+ # First check in libc, fallback to libintl, and as last chance build

--- a/ports/glib/Makefile
+++ b/ports/glib/Makefile
@@ -1,0 +1,1 @@
+include recurse.mk

--- a/ports/glib/README.md
+++ b/ports/glib/README.md
@@ -1,5 +1,56 @@
 # glib [![Build](https://github.com/qnx-ports/build-files/actions/workflows/glib.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/glib.yml)
 
+## Version notice
+
+glib currently has 2 different building profiles and only one of them should be installed on both the target and host system.
+
+# glib (main) for QNX (Recommanded)
+
+**NOTE**: currently both x86_64 and aarch64le are supported
+
+Current these versions are tested:
++ main
+
+See test reports in `tests/`. They remain the same as the other version
+
+## Dependencies notice
+
+
+To compile this library, you need the following packages installed:
++ [`zlib`](https://github.com/qnx-ports/build-files/edit/main/ports/zlib)
++ [`pcre2`](https://github.com/qnx-ports/build-files/edit/main/ports/pcre2)
++ [`libffi`](https://github.com/qnx-ports/build-files/edit/main/ports/libffi)
+
+**NOTE**: QNX ports are only supported from a Linux host operating system. Set `INSTALL_ROOT` enviroment variable to specify which directory glib will be installed to, make sure all dependencies and glib have the same `INSTALL_ROOT` variable.
+
+Use `$(nproc)` instead of `4` after `JLEVEL=` and `-j` if you want to use the maximum number of cores to build this project.
+32GB of RAM is recommended for using `JLEVEL=$(nproc)` or `-j$(nproc)`.
+
+## Compile the port for QNX
+
+
+Optional pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+```bash
+# Create a workspace
+mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+git clone https://gitlab.gnome.org/GNOME/glib.git
+
+# Optionally build the Docker image and create a container
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+# set enviroment variables
+cd ~/qnx_workspace
+source ~/qnx800/qnxsdp-env.sh
+
+# Build glib
+QNX_PROJECT_ROOT="$(pwd)/glib" JLEVEL=4 make -C build-files/ports/glib install
+```
+
+# glib for QNX
+
 **NOTE**: currently only aarch64le is supported.
 
 Current these versions are tested:

--- a/ports/glib/README.md
+++ b/ports/glib/README.md
@@ -1,5 +1,7 @@
 # glib [![Build](https://github.com/qnx-ports/build-files/actions/workflows/glib.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/glib.yml)
 
+Supports QNX7.1 and QNX8.0
+
 ## Version notice
 
 glib currently has 2 different building profiles and only one of them should be installed on both the target and host system.

--- a/ports/glib/common.mk
+++ b/ports/glib/common.mk
@@ -32,7 +32,7 @@ ALL_DEPENDENCIES = $(NAME)_all
 CFLAGS += $(FLAGS)
 
 #Define _QNX_SOURCE 
-CFLAGS += -D_QNX_SOURCE
+CFLAGS += -D_QNX_SOURCE -O3 -fPIC
 LDFLAGS += -Wl,--build-id=md5
 
 include $(MKFILES_ROOT)/qtargets.mk

--- a/ports/glib/common.mk
+++ b/ports/glib/common.mk
@@ -59,6 +59,7 @@ qnx_cross.cfg: $(PROJECT_ROOT)/qnx_cross.cfg.in
 	sed -i "s|QSDP|$(QNX_HOST)|" $@
 	sed -i "s|CPU|$(CPU)|" $@
 	sed -i "s|INSTALL_DIR|$(GLIB_INSTALL_DIR)|" $@
+	sed -i "s|QNX_TARGET_DIR|$(QNX_TARGET)/$(CPUVARDIR)/$(PREFIX)|" $@
 
 $(NAME)_all: qnx_cross.cfg
 # patch glib

--- a/ports/glib/common.mk
+++ b/ports/glib/common.mk
@@ -1,0 +1,81 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+include $(MKFILES_ROOT)/qmacros.mk
+
+NAME=glib
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+#choose Release or Debug
+MESON_BUILD_TYPE ?= release
+
+ALL_DEPENDENCIES = $(NAME)_all
+.PHONY: $(NAME)_all install check clean
+
+CFLAGS += $(FLAGS)
+
+#Define _QNX_SOURCE 
+CFLAGS += -D_QNX_SOURCE
+LDFLAGS += -Wl,--build-id=md5
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+GLIB_INSTALL_DIR=$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)
+
+# testing not availiable for gdk-pixbuf when cross-compiling
+BUILD_TESTING = OFF
+
+# Use submoduled Meson
+MESON := $(QNX_PROJECT_ROOT)/../meson/meson.py
+MESON_FLAGS :=  -Dxattr=false \
+                -Dtests=false\
+                --reconfigure \
+				--buildtype=$(MESON_BUILD_TYPE) \
+                --prefix=$(GLIB_INSTALL_DIR) \
+				--cross-file=../qnx_cross.cfg
+
+NINJA_ARGS := -j $(firstword $(JLEVEL) 1)
+
+# Set cross file
+qnx_cross.cfg: $(PROJECT_ROOT)/qnx_cross.cfg.in
+	cp $(PROJECT_ROOT)/qnx_cross.cfg.in $@
+	sed -i "s|QSDP|$(QNX_HOST)|" $@
+	sed -i "s|CPU|$(CPU)|" $@
+	sed -i "s|INSTALL_DIR|$(GLIB_INSTALL_DIR)|" $@
+
+$(NAME)_all: qnx_cross.cfg
+# patch glib
+	@cd $(QNX_PROJECT_ROOT) && if ! patch -N -i ../build-files/ports/glib/001-skip-detecting-latomic.patch; \
+								then echo "Patch applied"; fi
+	@mkdir -p build
+	@cd build && $(MESON) setup $(MESON_FLAGS) . $(QNX_PROJECT_ROOT)
+	@cd build && ninja $(NINJA_ARGS)
+
+install check: $(NAME)_all
+	@echo Installing...
+	@cd build && ninja install $(NINJA_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -rf qnx_cross.cfg
+	rm -rf build
+
+uninstall:
+

--- a/ports/glib/install_all.sh
+++ b/ports/glib/install_all.sh
@@ -10,6 +10,6 @@ DEP_COUNT=$(( DEP_COUNT - 1 ))
 for NN in $(seq 0 ${DEP_COUNT}); do
     if ${DEP_CLONE_CMD[$NN]}; then
         ./build-files/ports/"${DEP_NAME}"/install_all.sh
-        QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC}" make -C "build-files/ports/${DEP_NAME}/" install
+        QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install
     fi
 done

--- a/ports/glib/install_all.sh
+++ b/ports/glib/install_all.sh
@@ -1,0 +1,15 @@
+DEP_NAME=(zlib pcre2 libffi)
+DEP_NAME_SRC=(zlib pcre2 libffi)
+DEP_CLONE_CMD=("git clone -b v1.3.1 https://github.com/madler/zlib.git"
+               "git clone -b pcre2-10.45 https://github.com/PCRE2Project/pcre2.git"
+               "git clone -b v3.2.1 https://github.com/libffi/libffi.git")
+
+DEP_COUNT=${#DEP_NAME[@]}
+DEP_COUNT=$(( DEP_COUNT - 1 ))
+
+for NN in $(seq 0 ${DEP_COUNT}); do
+    if ${DEP_CLONE_CMD[$NN]}; then
+        ./build-files/ports/"${DEP_NAME}"/install_all.sh
+        QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC}" make -C "build-files/ports/${DEP_NAME}/" install
+    fi
+done

--- a/ports/glib/install_all.sh
+++ b/ports/glib/install_all.sh
@@ -9,7 +9,7 @@ DEP_COUNT=$(( DEP_COUNT - 1 ))
 
 for NN in $(seq 0 ${DEP_COUNT}); do
     if ${DEP_CLONE_CMD[$NN]}; then
-        ./build-files/ports/"${DEP_NAME}"/install_all.sh
+        ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
         QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install
     fi
 done

--- a/ports/glib/nto-aarch64-le/Makefile
+++ b/ports/glib/nto-aarch64-le/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/glib/nto-x86_64-o/Makefile
+++ b/ports/glib/nto-x86_64-o/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/glib/qnx_cross.cfg.in
+++ b/ports/glib/qnx_cross.cfg.in
@@ -1,0 +1,30 @@
+[constants]
+target_arch = 'CPU'
+target = 'nto' + target_arch
+qnx_host_dir = 'QSDP'
+qnx_install_dir = 'INSTALL_DIR'
+
+[host_machine]
+system = 'qnx'
+cpu_family = target_arch
+cpu = target_arch
+endian = 'little'
+
+[built-in options]
+c_link_args = ['-lm', '-lsocket', '-lgcc_s']
+
+[properties]
+growing_stack = false
+# pkg-config settings
+pkg_config_libdir = qnx_install_dir + '/lib/pkgconfig'
+
+[binaries]
+c = [qnx_host_dir + '/usr/bin/' + target + '-gcc']
+cpp = [qnx_host_dir + '/usr/bin/' + target + '-g++']
+ar = qnx_host_dir + '/usr/bin/' + target + '-ar'
+ld = qnx_host_dir + '/usr/bin/' + target + '-ld'
+strip = qnx_host_dir + '/usr/bin/' + target + '-strip'
+objcopy = qnx_host_dir + '/usr/bin/' + target + '-objcopy'
+# Using the host pkg-config
+pkg-config = 'pkg-config'
+windres = ''

--- a/ports/glib/qnx_cross.cfg.in
+++ b/ports/glib/qnx_cross.cfg.in
@@ -16,7 +16,7 @@ c_link_args = ['-lm', '-lsocket', '-lgcc_s']
 [properties]
 growing_stack = false
 # pkg-config settings
-pkg_config_libdir = qnx_install_dir + '/lib/pkgconfig'
+pkg_config_libdir = [qnx_install_dir + '/lib/pkgconfig', qnx_install_dir + '/share/pkgconfig']
 
 [binaries]
 c = [qnx_host_dir + '/usr/bin/' + target + '-gcc']

--- a/ports/glib/qnx_cross.cfg.in
+++ b/ports/glib/qnx_cross.cfg.in
@@ -13,6 +13,9 @@ endian = 'little'
 
 [built-in options]
 c_link_args = ['-lm', '-lsocket', '-lgcc_s']
+c_args = ['-D_QNX_SOURCE']
+cpp_link_args = c_link_args
+cpp_args = c_args
 
 [properties]
 growing_stack = false

--- a/ports/glib/qnx_cross.cfg.in
+++ b/ports/glib/qnx_cross.cfg.in
@@ -3,6 +3,7 @@ target_arch = 'CPU'
 target = 'nto' + target_arch
 qnx_host_dir = 'QSDP'
 qnx_install_dir = 'INSTALL_DIR'
+qnx_target_dir = 'QNX_TARGET_DIR'
 
 [host_machine]
 system = 'qnx'
@@ -16,7 +17,7 @@ c_link_args = ['-lm', '-lsocket', '-lgcc_s']
 [properties]
 growing_stack = false
 # pkg-config settings
-pkg_config_libdir = [qnx_install_dir + '/lib/pkgconfig', qnx_install_dir + '/share/pkgconfig']
+pkg_config_libdir = [qnx_install_dir + '/lib/pkgconfig', qnx_install_dir + '/share/pkgconfig', qnx_target_dir + '/lib/pkgconfig', qnx_target_dir + '/share/pkgconfig']
 
 [binaries]
 c = [qnx_host_dir + '/usr/bin/' + target + '-gcc']

--- a/ports/libffi/.gitignore
+++ b/ports/libffi/.gitignore
@@ -1,0 +1,7 @@
+!Makefile
+!nto-aarch64-le/Makefile
+!nto-x86_64-o/Makefile
+nto-aarch64-le/build
+nto-x86_64-o/build
+nto-aarch64-le/qnx_cross.cfg
+nto-x86_64-o/qnx_cross.cfg

--- a/ports/libffi/Makefile
+++ b/ports/libffi/Makefile
@@ -1,0 +1,1 @@
+include recurse.mk

--- a/ports/libffi/README.md
+++ b/ports/libffi/README.md
@@ -4,7 +4,7 @@ Supports QNX7.1 and QNX8.0
 
 ## QNX Software Center (QSC) compatibility warning
 
-It is very likely that another version of these binaries are shipped with the QNX image by QSC, hence installation of this library might introduce linking conflicts at runtime. Double check which version of it is linked when cross compiling your software and make sure the proper `LD_LIBRARY_PATH` is set for the dynamic linker to work properly
+It is very likely that another version of these binaries are shipped with the QNX image by QSC, hence installation of this library might introduce linking conflicts at runtime. Double check which version of it was linked when cross compiling your software and make sure the proper `LD_LIBRARY_PATH` is set for the dynamic linker to work properly
 
 **NOTE**: QNX ports are only supported from a Linux host operating system
 

--- a/ports/libffi/common.mk
+++ b/ports/libffi/common.mk
@@ -29,7 +29,7 @@ ALL_DEPENDENCIES = $(NAME)_all
 CFLAGS += $(FLAGS)
 
 #Define _QNX_SOURCE 
-CFLAGS += -D_QNX_SOURCE
+CFLAGS += -D_QNX_SOURCE -O3 -fPIC
 LDFLAGS += -Wl,--build-id=md5
 
 include $(MKFILES_ROOT)/qtargets.mk
@@ -45,8 +45,7 @@ export PKG_CONFIG_LIBDIR = $(PKG_CONFIG_LIBDIR_IN):$(PKG_CONFIG_TARGET_IN)
 #Config toolchain for qnx
 CONFIGURE_CMD = $(QNX_PROJECT_ROOT)/configure
 CONFIGURE_ARGS = --host=$(CPU)-*-$(OS) \
-                 --exec-prefix=$($(NAME)_INSTALL_DIR) \
-                 --prefix=$(INSTALL_ROOT)/$(PREFIX) \
+                 --prefix=$($(NAME)_INSTALL_DIR) \
                  --srcdir=$(QNX_PROJECT_ROOT)
 CONFIGURE_ENVS = CFLAGS="$(CFLAGS)" \
                  CXXFLAGS="$(CXXFLAGS)" \

--- a/ports/libffi/common.mk
+++ b/ports/libffi/common.mk
@@ -36,6 +36,11 @@ include $(MKFILES_ROOT)/qtargets.mk
 
 $(NAME)_INSTALL_DIR=$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)
 
+#Setup pkg-config dir
+export PKG_CONFIG_PATH=
+PKG_CONFIG_LIBDIR_IN = $($(NAME)_INSTALL_DIR)/lib/pkgconfig:$($(NAME)_INSTALL_DIR)/share/pkgconfig
+PKG_CONFIG_TARGET_IN = $(QNX_TARGET)/$(CPUVARDIR)/$(PREFIX)/lib/pkgconfig:$(QNX_TARGET)/$(CPUVARDIR)/$(PREFIX)/share/pkgconfig
+export PKG_CONFIG_LIBDIR = $(PKG_CONFIG_LIBDIR_IN):$(PKG_CONFIG_TARGET_IN)
 
 #Config toolchain for qnx
 CONFIGURE_CMD = $(QNX_PROJECT_ROOT)/configure

--- a/ports/libffi/common.mk
+++ b/ports/libffi/common.mk
@@ -1,0 +1,75 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+include $(MKFILES_ROOT)/qmacros.mk
+
+NAME=libffi
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+ALL_DEPENDENCIES = $(NAME)_all
+.PHONY: $(NAME)_all install check clean
+
+CFLAGS += $(FLAGS)
+
+#Define _QNX_SOURCE 
+CFLAGS += -D_QNX_SOURCE
+LDFLAGS += -Wl,--build-id=md5
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+$(NAME)_INSTALL_DIR=$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)
+
+
+#Config toolchain for qnx
+CONFIGURE_CMD = $(QNX_PROJECT_ROOT)/configure
+CONFIGURE_ARGS = --host=$(CPU)-*-$(OS) \
+                 --exec-prefix=$($(NAME)_INSTALL_DIR) \
+                 --prefix=$(INSTALL_ROOT)/$(PREFIX) \
+                 --srcdir=$(QNX_PROJECT_ROOT)
+CONFIGURE_ENVS = CFLAGS="$(CFLAGS)" \
+                 CXXFLAGS="$(CXXFLAGS)" \
+                 LDFLAGS="$(LDFLAGS)" \
+                 CC="${QNX_HOST}/usr/bin/qcc -Vgcc_$(OS)$(CPUVARDIR)" \
+                 CXX="${QNX_HOST}/usr/bin/q++ -Vgcc_$(OS)$(CPUVARDIR)" \
+                 AR="${QNX_HOST}/usr/bin/$(OS)$(CPU)-ar" \
+                 AS="${QNX_HOST}/usr/bin/qcc -Vgcc_$(OS)$(CPUVARDIR)" \
+                 RANDLIB="${QNX_HOST}/usr/bin/$(OS)$(CPU)-ranlib" \
+
+BIN_INSTALL_CMD = make VERBOSE=1 install $(MAKE_ARGS)
+
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+$(NAME)_all:
+	@mkdir -p build
+	@cd $(QNX_PROJECT_ROOT) && ./autogen.sh
+	@cd build && $(CONFIGURE_CMD) $(CONFIGURE_ARGS) $(CONFIGURE_ENVS)
+	@cd build && make $(MAKE_ARGS)
+
+install check: $(NAME)_all
+	@echo Installing...
+	@cd build && make install $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -rf build
+
+uninstall:
+

--- a/ports/libffi/common.mk
+++ b/ports/libffi/common.mk
@@ -30,6 +30,7 @@ CFLAGS += $(FLAGS)
 
 #Define _QNX_SOURCE 
 CFLAGS += -D_QNX_SOURCE -O3 -fPIC
+CXXFLAGS += $(CFLAGS)
 LDFLAGS += -Wl,--build-id=md5
 
 include $(MKFILES_ROOT)/qtargets.mk

--- a/ports/libffi/nto-aarch64-le/Makefile
+++ b/ports/libffi/nto-aarch64-le/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/libffi/nto-x86_64-o/Makefile
+++ b/ports/libffi/nto-x86_64-o/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/pcre2/.gitignore
+++ b/ports/pcre2/.gitignore
@@ -1,0 +1,5 @@
+!Makefile
+!nto-aarch64-le/Makefile
+!nto-x86_64-o/Makefile
+nto-aarch64-le/build
+nto-x86_64-o/build

--- a/ports/pcre2/Makefile
+++ b/ports/pcre2/Makefile
@@ -1,0 +1,1 @@
+include recurse.mk

--- a/ports/pcre2/README.md
+++ b/ports/pcre2/README.md
@@ -1,4 +1,4 @@
-# libffi [![Build](https://github.com/qnx-ports/build-files/actions/workflows/libffi.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/libffi.yml)
+# pcre2 [![Build](https://github.com/qnx-ports/build-files/actions/workflows/pcre2.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/pcre2.yml)
 
 Supports QNX7.1 and QNX8.0
 
@@ -29,17 +29,17 @@ cd build-files/docker
 # source qnxsdp-env.sh in
 source ~/qnx800/qnxsdp-env.sh
 
-# Clone libffi
+# Clone pcre2
 cd ~/qnx_workspace
-git clone https://github.com/libffi/libffi.git
+git clone https://github.com/PCRE2Project/pcre2.git
 
-# check out to v3.2.1
-cd libffi
-git checkout v3.2.1
+# check out to pcre2-10.45
+cd pcre2
+git checkout pcre2-10.45
 cd ..
 
-# Build libffi
-QNX_PROJECT_ROOT="$(pwd)/libffi" JLEVEL=4 make -C build-files/ports/libffi install
+# Build pcre2
+QNX_PROJECT_ROOT="$(pwd)/pcre2" JLEVEL=4 make -C build-files/ports/pcre2 install
 ```
 
 # Compile the port for QNX on Ubuntu host
@@ -47,18 +47,18 @@ QNX_PROJECT_ROOT="$(pwd)/libffi" JLEVEL=4 make -C build-files/ports/libffi insta
 # Clone the repos
 mkdir -p ~/qnx_workspace && cd qnx_workspace
 git clone https://github.com/qnx-ports/build-files.git
-git clone https://github.com/libffi/libffi.git
+git clone https://github.com/PCRE2Project/pcre2.git
 
-# check libffi out to v3.2.1
-cd libffi
-git checkout v3.2.1
+# check out to pcre2-10.45
+cd pcre2
+git checkout pcre2-10.45
 cd ..
 
 # source qnxsdp-env.sh
 source ~/qnx800/qnxsdp-env.sh
 
-# Build libffi
-QNX_PROJECT_ROOT="$(pwd)/libffi" JLEVEL=4 make -C build-files/ports/libffi install
+# Build pcre2
+QNX_PROJECT_ROOT="$(pwd)/pcre2" JLEVEL=4 make -C build-files/ports/pcre2 install
 ```
 
 # Deploy binaries via SSH
@@ -67,13 +67,29 @@ QNX_PROJECT_ROOT="$(pwd)/libffi" JLEVEL=4 make -C build-files/ports/libffi insta
 TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
 TARGET_USER=<target-username>
 
-scp -r ~/qnx800/target/qnx/aarch64le/usr/local/lib/libffi* $TARGET_USER@$TARGET_IP_ADDRESS:~/lib
+scp -r ~/qnx800/target/qnx/aarch64le/usr/local/bin/pcre2* $TARGET_USER@$TARGET_IP_ADDRESS:~/bin
+scp -r ~/qnx800/target/qnx/aarch64le/usr/local/lib/libpcre2* $TARGET_USER@$TARGET_IP_ADDRESS:~/lib
 ```
 
-If `~/lib` directory do not exist, create them with:
+If `~/bin` or `~/lib` directory does not exist, create them with:
 ```bash
+ssh $TARGET_USER@$TARGET_IP_ADDRESS "mkdir -p ~/bin"
 ssh $TARGET_USER@$TARGET_IP_ADDRESS "mkdir -p ~/lib"
 ````
 
 # Tests
-Tests are not avaliable.
+Tests are avaliable; Test related to `locale` are failing due to the lack of support in QNX image
+Make sure you have all required binaries deployed metioned above
+```bash
+# copy the test data
+scp -r pcre2/testdata $TARGET_USER@$TARGET_IP_ADDRESS:~/bin
+# copy the test scripts
+scp -r build-files/ports/pcre2/nto-aarch64-le/build/pcre2_test.sh $TARGET_USER@$TARGET_IP_ADDRESS:~/bin
+scp -r pcre2/RunTest $TARGET_USER@$TARGET_IP_ADDRESS:~/bin
+
+# ssh to your target system 
+ssh $TARGET_USER@$TARGET_IP_ADDRESS
+
+# enter the bin directory and run the tests
+sh ./RunTest
+````

--- a/ports/pcre2/README.md
+++ b/ports/pcre2/README.md
@@ -4,7 +4,7 @@ Supports QNX7.1 and QNX8.0
 
 ## QNX Software Center (QSC) compatibility warning
 
-It is very likely that another version of these binaries are shipped with the QNX image by QSC, hence installation of this library might introduce linking conflicts at runtime. Double check which version of it is linked when cross compiling your software and make sure the proper `LD_LIBRARY_PATH` is set for the dynamic linker to work properly
+It is very likely that another version of these binaries are shipped with the QNX image by QSC, hence installation of this library might introduce linking conflicts at runtime. Double check which version of it was linked when cross compiling your software and make sure the proper `LD_LIBRARY_PATH` is set for the dynamic linker to work properly
 
 **NOTE**: QNX ports are only supported from a Linux host operating system
 

--- a/ports/pcre2/common.mk
+++ b/ports/pcre2/common.mk
@@ -1,0 +1,93 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+include $(MKFILES_ROOT)/qmacros.mk
+
+NAME=pcre2
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+ALL_DEPENDENCIES = $(NAME)_all
+.PHONY: $(NAME)_all install check clean
+
+CFLAGS += $(FLAGS)
+
+#Define _QNX_SOURCE for LLVM libc++ on QNX 7
+CFLAGS += -D_QNX_SOURCE
+LDFLAGS += -Wl,--build-id=md5
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+BUILD_TESTING ?= OFF
+
+#Search paths for all of CMake's find_* functions --
+#headers, libraries, etc.
+#
+#$(QNX_TARGET): for architecture-agnostic files shipped with SDP (e.g. headers)
+#$(QNX_TARGET)/$(CPUVARDIR): for architecture-specific files in SDP
+#$(INSTALL_ROOT)/$(CPUVARDIR): any packages that may have been installed in the staging area
+CMAKE_FIND_ROOT_PATH := $(QNX_TARGET);$(QNX_TARGET)/$(CPUVARDIR);$(INSTALL_ROOT)/$(CPUVARDIR)
+
+#Path to CMake modules; These are CMake files installed by other packages
+#for downstreams to discover them automatically. We support discovering
+#CMake-based packages from inside SDP or in the staging area.
+#Note that CMake modules can automatically detect the prefix they are
+#installed in.
+CMAKE_MODULE_PATH := $(QNX_TARGET)/$(CPUVARDIR)/$(PREFIX)/lib/cmake;$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib/cmake
+
+#Headers from INSTALL_ROOT need to be made available by default
+#because CMake and pkg-config do not necessary add it automatically
+#if the include path is "default"
+CFLAGS += -I$(INSTALL_ROOT)/$(PREFIX)/include -I$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/include
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_SYSTEM_PROCESSOR_ENDIAN=$(CPUVARDIR) \
+             -DCMAKE_SYSTEM_PROCESSOR=$(CPU) \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_CXX_COMPILER_TARGET=gcc_nto$(CPUVARDIR) \
+             -DCMAKE_C_COMPILER_TARGET=gcc_nto$(CPUVARDIR) \
+             -DCMAKE_INSTALL_PREFIX="$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)" \
+             -DCMAKE_STAGING_PREFIX="$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)" \
+             -DCMAKE_MODULE_PATH="$(CMAKE_MODULE_PATH)" \
+             -DCMAKE_FIND_ROOT_PATH="$(CMAKE_FIND_ROOT_PATH)" \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+$(NAME)_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: $(NAME)_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -rf build
+
+uninstall:
+

--- a/ports/pcre2/common.mk
+++ b/ports/pcre2/common.mk
@@ -32,7 +32,7 @@ ALL_DEPENDENCIES = $(NAME)_all
 CFLAGS += $(FLAGS)
 
 #Define _QNX_SOURCE for LLVM libc++ on QNX 7
-CFLAGS += -D_QNX_SOURCE
+CFLAGS += -D_QNX_SOURCE -O3 -fPIC
 LDFLAGS += -Wl,--build-id=md5
 
 include $(MKFILES_ROOT)/qtargets.mk

--- a/ports/pcre2/nto-aarch64-le/Makefile
+++ b/ports/pcre2/nto-aarch64-le/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/pcre2/nto-x86_64-o/Makefile
+++ b/ports/pcre2/nto-x86_64-o/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/pcre2/qnx.nto.toolchain.cmake
+++ b/ports/pcre2/qnx.nto.toolchain.cmake
@@ -1,0 +1,35 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+set(AWK "awk" CACHE PATH "awk")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR_ENDIAN} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR_ENDIAN} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR_ENDIAN} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")

--- a/ports/zlib/.gitignore
+++ b/ports/zlib/.gitignore
@@ -1,0 +1,5 @@
+!Makefile
+!nto-aarch64-le/Makefile
+!nto-x86_64-o/Makefile
+nto-aarch64-le/build
+nto-x86_64-o/build

--- a/ports/zlib/Makefile
+++ b/ports/zlib/Makefile
@@ -1,0 +1,1 @@
+include recurse.mk

--- a/ports/zlib/README.md
+++ b/ports/zlib/README.md
@@ -4,7 +4,7 @@ Supports QNX7.1 and QNX8.0
 
 ## QNX Software Center (QSC) compatibility warning for libz-ng and zlib
 
-It is very likely that another version of these binaries are shipped with the QNX image by QSC, hence installation of this library might introduce linking conflicts at runtime. Double check which version of it is linked when cross compiling your software and make sure the proper `LD_LIBRARY_PATH` is set for the dynamic linker to work properly.
+It is very likely that another version of these binaries are shipped with the QNX image by QSC, hence installation of this library might introduce linking conflicts at runtime. Double check which version of it was linked when cross compiling your software and make sure the proper `LD_LIBRARY_PATH` is set for the dynamic linker to work properly.
 
 This library is not an update to the existing QSC library, the existing `libz.so`, provided by zlib-ng, shipped by QSC is a so call "drop in replacement" for zlib. Please check details in [here](https://github.com/zlib-ng/zlib-ng).
 

--- a/ports/zlib/README.md
+++ b/ports/zlib/README.md
@@ -1,0 +1,92 @@
+# zlib [![Build](https://github.com/qnx-ports/build-files/actions/workflows/zlib.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/zlib.yml)
+
+Supports QNX7.1 and QNX8.0
+
+## QNX Software Center (QSC) compatibility warning for libz-ng and zlib
+
+It is very likely that another version of these binaries are shipped with the QNX image by QSC, hence installation of this library might introduce linking conflicts at runtime. Double check which version of it is linked when cross compiling your software and make sure the proper `LD_LIBRARY_PATH` is set for the dynamic linker to work properly.
+
+This library is not an update to the existing QSC library, the existing `libz.so`, provided by zlib-ng, shipped by QSC is a so call "drop in replacement" for zlib. Please check details in [here](https://github.com/zlib-ng/zlib-ng).
+
+**NOTE**: QNX ports are only supported from a Linux host operating system
+
+Use `$(nproc)` instead of `4` after `JLEVEL=` and `-j` if you want to use the maximum number of cores to build this project.
+32GB of RAM is recommended for using `JLEVEL=$(nproc)` or `-j$(nproc)`.
+
+# Compile the port for QNX in a Docker container
+
+Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+```bash
+# Create a workspace
+mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+
+# Build the Docker image and create a container
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+# Now you are in the Docker container
+
+# source qnxsdp-env.sh in
+source ~/qnx800/qnxsdp-env.sh
+
+# Clone zlib
+cd ~/qnx_workspace
+git clone https://github.com/madler/zlib.git
+# checkout to the latest stable
+cd zlib
+git checkout v1.3.1
+cd ..
+
+# Build zlib
+QNX_PROJECT_ROOT="$(pwd)/zlib" JLEVEL=4 make -C build-files/ports/zlib install
+```
+
+# Compile the port for QNX on Ubuntu host
+```bash
+# Clone the repos
+mkdir -p ~/qnx_workspace && cd qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+git clone https://github.com/madler/zlib.git
+# checkout to the latest stable
+cd zlib
+git checkout v1.3.1
+cd ..
+
+# source qnxsdp-env.sh
+source ~/qnx800/qnxsdp-env.sh
+
+# Build zlib
+QNX_PROJECT_ROOT="$(pwd)/zlib" JLEVEL=4 make -C build-files/ports/zlib install
+```
+
+# Deploy binaries via SSH
+```bash
+#Set your target's IP here
+TARGET_IP_ADDRESS=<target-ip-address-or-hostname>
+TARGET_USER=<target-username>
+
+scp -r ~/qnx800/target/qnx/aarch64le/usr/local/lib/libz* $TARGET_USER@$TARGET_IP_ADDRESS:~/lib
+```
+
+If the `~/lib` directory do not exist, create them with:
+```bash
+ssh $TARGET_USER@$TARGET_IP_ADDRESS "mkdir -p ~/lib"
+````
+
+# Tests
+Tests are avaliable; currently all tests are passed.
+
+To run tests, make sure you have already deployed required binaries metioned above and excute the following.
+```base
+scp ./build-files/ports/zlib/nto-aarch64-le/build/example* $TARGET_USER@$TARGET_IP_ADDRESS:~
+scp ./build-files/ports/zlib/nto-aarch64-le/build/minigzip* $TARGET_USER@$TARGET_IP_ADDRESS:~
+
+# On your target system, navigate to ~, excute the following commands to run tests
+./example
+./example64
+./minigzip
+./minigzip64
+
+```

--- a/ports/zlib/common.mk
+++ b/ports/zlib/common.mk
@@ -32,7 +32,7 @@ ALL_DEPENDENCIES = $(NAME)_all
 CFLAGS += $(FLAGS)
 
 #Define _QNX_SOURCE for LLVM libc++ on QNX 7
-CFLAGS += -D_QNX_SOURCE
+CFLAGS += -D_QNX_SOURCE -O3 -fPIC
 LDFLAGS += -Wl,--build-id=md5
 
 include $(MKFILES_ROOT)/qtargets.mk

--- a/ports/zlib/common.mk
+++ b/ports/zlib/common.mk
@@ -1,0 +1,93 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+include $(MKFILES_ROOT)/qmacros.mk
+
+NAME=zlib
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+ALL_DEPENDENCIES = $(NAME)_all
+.PHONY: $(NAME)_all install check clean
+
+CFLAGS += $(FLAGS)
+
+#Define _QNX_SOURCE for LLVM libc++ on QNX 7
+CFLAGS += -D_QNX_SOURCE
+LDFLAGS += -Wl,--build-id=md5
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+BUILD_TESTING ?= OFF
+
+#Search paths for all of CMake's find_* functions --
+#headers, libraries, etc.
+#
+#$(QNX_TARGET): for architecture-agnostic files shipped with SDP (e.g. headers)
+#$(QNX_TARGET)/$(CPUVARDIR): for architecture-specific files in SDP
+#$(INSTALL_ROOT)/$(CPUVARDIR): any packages that may have been installed in the staging area
+CMAKE_FIND_ROOT_PATH := $(QNX_TARGET);$(QNX_TARGET)/$(CPUVARDIR);$(INSTALL_ROOT)/$(CPUVARDIR)
+
+#Path to CMake modules; These are CMake files installed by other packages
+#for downstreams to discover them automatically. We support discovering
+#CMake-based packages from inside SDP or in the staging area.
+#Note that CMake modules can automatically detect the prefix they are
+#installed in.
+CMAKE_MODULE_PATH := $(QNX_TARGET)/$(CPUVARDIR)/$(PREFIX)/lib/cmake;$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib/cmake
+
+#Headers from INSTALL_ROOT need to be made available by default
+#because CMake and pkg-config do not necessary add it automatically
+#if the include path is "default"
+CFLAGS += -I$(INSTALL_ROOT)/$(PREFIX)/include -I$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/include
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_SYSTEM_PROCESSOR_ENDIAN=$(CPUVARDIR) \
+             -DCMAKE_SYSTEM_PROCESSOR=$(CPU) \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_CXX_COMPILER_TARGET=gcc_nto$(CPUVARDIR) \
+             -DCMAKE_C_COMPILER_TARGET=gcc_nto$(CPUVARDIR) \
+             -DCMAKE_INSTALL_PREFIX="$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)" \
+             -DCMAKE_STAGING_PREFIX="$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)" \
+             -DCMAKE_MODULE_PATH="$(CMAKE_MODULE_PATH)" \
+             -DCMAKE_FIND_ROOT_PATH="$(CMAKE_FIND_ROOT_PATH)" \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+$(NAME)_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: $(NAME)_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -rf build
+
+uninstall:
+

--- a/ports/zlib/nto-aarch64-le/Makefile
+++ b/ports/zlib/nto-aarch64-le/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/zlib/nto-x86_64-o/Makefile
+++ b/ports/zlib/nto-x86_64-o/Makefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/zlib/qnx.nto.toolchain.cmake
+++ b/ports/zlib/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR_ENDIAN} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR_ENDIAN} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR_ENDIAN} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")


### PR DESCRIPTION
Add x86_64 support for glib, now support QNX710 and 800
Also add proper dependency support for glib, including separated pcre2, libffi and zlib.