### PR TITLE
GTK dependencies: improce install_all.sh for cairo, libpng, fontconfig, freetype, gdk-pixbuf, libthai

### DIFF
--- a/ports/cairo/install_all.sh
+++ b/ports/cairo/install_all.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 DEP_NAME=(pixman freetype fontconfig glib)
 DEP_NAME_SRC=(pixman freetype fontconfig glib)
 DEP_CLONE_CMD=("git clone -b pixman-0.44.2 https://gitlab.freedesktop.org/pixman/pixman.git"
@@ -9,11 +11,24 @@ DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))
 
 for NN in $(seq 0 ${DEP_COUNT}); do
-    if ${DEP_CLONE_CMD[$NN]}; then
-        chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
+    if ! ${DEP_CLONE_CMD[$NN]}; then
+        echo "A git command just fail, but it maybe expected."
+        echo "If the build process does not stop, you can ignore this error."
+    fi
+
+    if test -d "$(pwd)/${DEP_NAME_SRC[$NN]}"; then
+        if ! chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh; then
+            echo "A recursive install_all.sh call fails, this maybe expected."
+            echo "If the build process is successful at the end, it can be safely ignored."
+        fi
+
         ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
         if ! QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install; then
+            echo "install_all.sh build fails."
             exit 1; 
         fi
+    else
+        echo "The source codes of "${DEP_NAME[$NN]}" are not cloned, abort."
+        exit 1;
     fi
 done

--- a/ports/fontconfig/install_all.sh
+++ b/ports/fontconfig/install_all.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 DEP_NAME=(libexpat libiconv freetype)
 DEP_NAME_SRC=(libexpat/expat libiconv-1.18 freetype)
 DEP_CLONE_CMD=("git clone -b R_2_6_4 https://github.com/libexpat/libexpat.git"
@@ -9,11 +11,24 @@ DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))
 
 for NN in $(seq 0 ${DEP_COUNT}); do
-    if ${DEP_CLONE_CMD[$NN]}; then
-        chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
+    if ! ${DEP_CLONE_CMD[$NN]}; then
+        echo "A git command just fail, but it maybe expected."
+        echo "If the build process does not stop, you can ignore this error."
+    fi
+
+    if test -d "$(pwd)/${DEP_NAME_SRC[$NN]}"; then
+        if ! chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh; then
+            echo "A recursive install_all.sh call fails, this maybe expected."
+            echo "If the build process is successful at the end, it can be safely ignored."
+        fi
+
         ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
         if ! QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install; then
+            echo "install_all.sh build fails."
             exit 1; 
         fi
+    else
+        echo "The source codes of "${DEP_NAME[$NN]}" are not cloned, abort."
+        exit 1;
     fi
 done

--- a/ports/freetype/install_all.sh
+++ b/ports/freetype/install_all.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 DEP_NAME=(zlib brotli bzip2 libpng)
 DEP_NAME_SRC=(zlib brotli bzip2 libpng)
 DEP_CLONE_CMD=("git clone -b v1.3.1 https://github.com/madler/zlib.git"
@@ -9,11 +11,24 @@ DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))
 
 for NN in $(seq 0 ${DEP_COUNT}); do
-    if ${DEP_CLONE_CMD[$NN]}; then
-        chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
+    if ! ${DEP_CLONE_CMD[$NN]}; then
+        echo "A git command just fail, but it maybe expected."
+        echo "If the build process does not stop, you can ignore this error."
+    fi
+
+    if test -d "$(pwd)/${DEP_NAME_SRC[$NN]}"; then
+        if ! chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh; then
+            echo "A recursive install_all.sh call fails, this maybe expected."
+            echo "If the build process is successful at the end, it can be safely ignored."
+        fi
+
         ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
         if ! QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install; then
+            echo "install_all.sh build fails."
             exit 1; 
         fi
+    else
+        echo "The source codes of "${DEP_NAME[$NN]}" are not cloned, abort."
+        exit 1;
     fi
 done

--- a/ports/gdk-pixbuf/install_all.sh
+++ b/ports/gdk-pixbuf/install_all.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 DEP_NAME=(zlib libpng libjpeg-turbo glib)
 DEP_NAME_SRC=(zlib libpng libjpeg-turbo glib)
 DEP_CLONE_CMD=("git clone -b v1.3.1 https://github.com/madler/zlib.git"
@@ -9,11 +11,24 @@ DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))
 
 for NN in $(seq 0 ${DEP_COUNT}); do
-    if ${DEP_CLONE_CMD[$NN]}; then
-        chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
+    if ! ${DEP_CLONE_CMD[$NN]}; then
+        echo "A git command just fail, but it maybe expected."
+        echo "If the build process does not stop, you can ignore this error."
+    fi
+
+    if test -d "$(pwd)/${DEP_NAME_SRC[$NN]}"; then
+        if ! chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh; then
+            echo "A recursive install_all.sh call fails, this maybe expected."
+            echo "If the build process is successful at the end, it can be safely ignored."
+        fi
+
         ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
         if ! QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install; then
+            echo "install_all.sh build fails."
             exit 1; 
         fi
+    else
+        echo "The source codes of "${DEP_NAME[$NN]}" are not cloned, abort."
+        exit 1;
     fi
 done

--- a/ports/libpng/install_all.sh
+++ b/ports/libpng/install_all.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 DEP_NAME=(zlib)
 DEP_NAME_SRC=(zlib)
 DEP_CLONE_CMD=("git clone -b v1.3.1 https://github.com/madler/zlib.git")
@@ -6,11 +8,24 @@ DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))
 
 for NN in $(seq 0 ${DEP_COUNT}); do
-    if ${DEP_CLONE_CMD[$NN]}; then
-        chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
+    if ! ${DEP_CLONE_CMD[$NN]}; then
+        echo "A git command just fail, but it maybe expected."
+        echo "If the build process does not stop, you can ignore this error."
+    fi
+
+    if test -d "$(pwd)/${DEP_NAME_SRC[$NN]}"; then
+        if ! chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh; then
+            echo "A recursive install_all.sh call fails, this maybe expected."
+            echo "If the build process is successful at the end, it can be safely ignored."
+        fi
+
         ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
         if ! QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install; then
+            echo "install_all.sh build fails."
             exit 1; 
         fi
+    else
+        echo "The source codes of "${DEP_NAME[$NN]}" are not cloned, abort."
+        exit 1;
     fi
 done

--- a/ports/libthai/install_all.sh
+++ b/ports/libthai/install_all.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 DEP_NAME=(libdatrie)
 DEP_NAME_SRC=(libdatrie-0.2.13)
 DEP_CLONE_CMD=("echo")
@@ -8,11 +10,24 @@ DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))
 
 for NN in $(seq 0 ${DEP_COUNT}); do
-    if ${DEP_CLONE_CMD[$NN]}; then
-        chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
+    if ! ${DEP_CLONE_CMD[$NN]}; then
+        echo "A git command just fail, but it maybe expected."
+        echo "If the build process does not stop, you can ignore this error."
+    fi
+
+    if test -d "$(pwd)/${DEP_NAME_SRC[$NN]}"; then
+        if ! chmod +x ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh; then
+            echo "A recursive install_all.sh call fails, this maybe expected."
+            echo "If the build process is successful at the end, it can be safely ignored."
+        fi
+
         ./build-files/ports/"${DEP_NAME[$NN]}"/install_all.sh
         if ! QNX_PROJECT_ROOT="$(pwd)/${DEP_NAME_SRC[$NN]}" make -C "build-files/ports/${DEP_NAME[$NN]}/" install; then
+            echo "install_all.sh build fails."
             exit 1; 
         fi
+    else
+        echo "The source codes of "${DEP_NAME[$NN]}" are not cloned, abort."
+        exit 1;
     fi
 done


### PR DESCRIPTION
...
This resolve issues discovered during CLT build tests.