### PR TITLE
ros2: add link to qnx-ros2-workspace in README

### DIFF
--- a/ports/ros2/README.md
+++ b/ports/ros2/README.md
@@ -215,4 +215,4 @@ Please refer to https://docs.ros.org/en/humble/Tutorials/Demos/dummy-robot-demo.
 
 # How to build your own node
 
-Please refer to the README.md inside the qnx-ros2-workspace folder.
+Please refer to the README.md inside the cloned [qnx-ros2-workspace](https://github.com/qnx-ports/qnx-ros2-workspace/tree/main) repository.


### PR DESCRIPTION
The pull requests add a link to the qnx-ros2-workspace needed for building ROS nodes.
It is useful especially for newcomers, who do not know about the existence of this repository.