### PR TITLE
cmake version and dockers scripts update

### DIFF
--- a/.github/workflows/CANdb.yml
+++ b/.github/workflows/CANdb.yml
@@ -44,12 +44,12 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ghcr.io/qnx-ports/sdp-build-env:latest
 
     - name: Build CANdb
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ghcr.io/qnx-ports/sdp-build-env:latest
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |

--- a/.github/workflows/Catch2.yml
+++ b/.github/workflows/Catch2.yml
@@ -44,12 +44,12 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ghcr.io/qnx-ports/sdp-build-env:latest
 
     - name: Build Catch2
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ghcr.io/qnx-ports/sdp-build-env:latest
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |

--- a/.github/workflows/asio.yml
+++ b/.github/workflows/asio.yml
@@ -44,12 +44,12 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ghcr.io/qnx-ports/sdp-build-env:latest
 
     - name: Build asio
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ghcr.io/qnx-ports/sdp-build-env:latest
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |

--- a/.github/workflows/dlt-daemon.yml
+++ b/.github/workflows/dlt-daemon.yml
@@ -45,12 +45,12 @@ jobs:
 
     - name: Pull build environment
       run: |
-        docker pull ghcr.io/qnx-ports/sdp800-build-env:latest
+        docker pull ghcr.io/qnx-ports/sdp-build-env:latest
 
     - name: Build dlt-daemon
       uses: addnab/docker-run-action@v3
       with:
-        image: ghcr.io/qnx-ports/sdp800-build-env:latest
+        image: ghcr.io/qnx-ports/sdp-build-env:latest
         options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
         shell: bash
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,11 +111,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y && \
 	python3.11-distutils \
 	rename
 
-# Install CMake 3.22
-RUN cd /opt && sudo wget https://cmake.org/files/v3.22/cmake-3.22.0-linux-x86_64.sh && \
-	sudo mkdir /opt/cmake-3.22.0-linux-x86_64 && \
-	yes | sudo sh cmake-3.22.0-linux-x86_64.sh --prefix=/opt/cmake-3.22.0-linux-x86_64 --skip-license && \
-	sudo ln -s /opt/cmake-3.22.0-linux-x86_64/bin/cmake /usr/local/bin/cmake
+# Install CMake 3.31.7
+RUN cd /opt && sudo wget https://cmake.org/files/v3.31/cmake-3.31.7-linux-x86_64.sh && \
+	sudo mkdir /opt/cmake-3.31.7-linux-x86_64 && \
+	yes | sudo sh cmake-3.31.7-linux-x86_64.sh --prefix=/opt/cmake-3.31.7-linux-x86_64 --skip-license && \
+	sudo ln -s /opt/cmake-3.31.7-linux-x86_64/bin/cmake /usr/local/bin/cmake
 
 # Install APK dependencies
 RUN apt-get install -y \

--- a/docker/docker-build-qnx-image.sh
+++ b/docker/docker-build-qnx-image.sh
@@ -2,11 +2,6 @@
 
 QNX_SDP_VERSION=${QNX_SDP_VERSION:-qnx800}
 
-if [ ! -d ${HOME}/${QNX_SDP_VERSION} ]; then
-    echo "ERROR: The SDP's path ${HOME}/${QNX_SDP_VERSION} is not available."
-    exit 1
-fi
-
 echo "Using SDP from ${HOME}/${QNX_SDP_VERSION}"
 
 docker build -t $QNX_SDP_VERSION \

--- a/docker/docker-build-qnx-image.sh
+++ b/docker/docker-build-qnx-image.sh
@@ -2,7 +2,12 @@
 
 QNX_SDP_VERSION=${QNX_SDP_VERSION:-qnx800}
 
-echo "Use SDP from ${HOME}/${QNX_SDP_VERSION}"
+if [ ! -d ${HOME}/${QNX_SDP_VERSION} ]; then
+    echo "ERROR: The SDP's path ${HOME}/${QNX_SDP_VERSION} is not available."
+    exit 1
+fi
+
+echo "Using SDP from ${HOME}/${QNX_SDP_VERSION}"
 
 docker build -t $QNX_SDP_VERSION \
   --build-arg USER_NAME="$(id --user --name | awk '{print $1;}')" \

--- a/docker/docker-build-qnx-image.sh
+++ b/docker/docker-build-qnx-image.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-QNX_SDP_VERSION=qnx800
+QNX_SDP_VERSION=${QNX_SDP_VERSION:-qnx800}
+
+echo "Use SDP from ${HOME}/${QNX_SDP_VERSION}"
 
 docker build -t $QNX_SDP_VERSION \
   --build-arg USER_NAME="$(id --user --name | awk '{print $1;}')" \

--- a/docker/docker-create-container.sh
+++ b/docker/docker-create-container.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-QNX_SDP_VERSION=qnx800
+QNX_SDP_VERSION=${QNX_SDP_VERSION:-qnx800}
+
+echo "Use SDP from ${HOME}/${QNX_SDP_VERSION}"
 
 docker run -it \
   --net=host \

--- a/docker/docker-create-container.sh
+++ b/docker/docker-create-container.sh
@@ -2,7 +2,12 @@
 
 QNX_SDP_VERSION=${QNX_SDP_VERSION:-qnx800}
 
-echo "Use SDP from ${HOME}/${QNX_SDP_VERSION}"
+if [ ! -d ${HOME}/${QNX_SDP_VERSION} ]; then
+    echo "ERROR: The SDP's path ${HOME}/${QNX_SDP_VERSION} is not available."
+    exit 1
+fi
+
+echo "Using SDP from ${HOME}/${QNX_SDP_VERSION}"
 
 docker run -it \
   --net=host \

--- a/docker/welcome.sh
+++ b/docker/welcome.sh
@@ -13,6 +13,6 @@ echo "
 # Setup environment variables
 echo "QNX Environment variables are set to:"
 source /usr/local/qnx/env/bin/activate
-source $HOME/qnx800/qnxsdp-env.sh
+source $HOME/$QNX_SDP_VERSION/qnxsdp-env.sh
 cd $HOME/qnx_workspace
 echo ""


### PR DESCRIPTION
Docker cmake: update to 3.31.7
Docker scripts: handling external QNX_SDP_VERSION.

This supports new versions of CMake presets and
gives the possibility to set QNX_SDP_VERSION outside the scripts.