### PR TITLE
ntttcp: Adding build files

### DIFF
--- a/.github/workflows/ntttcp.yml
+++ b/.github/workflows/ntttcp.yml
@@ -63,4 +63,4 @@ jobs:
               source ~/qnx/800/qnxsdp-env.sh
             fi
             cd ~/workspace
-            make -C build-files/ports/ntttcp install
+            BUILD_TESTING="ON" QNX_PROJECT_ROOT="$(pwd)/ntttcp-for-linux/src" make -C build-files/ports/ntttcp install

--- a/.github/workflows/ntttcp.yml
+++ b/.github/workflows/ntttcp.yml
@@ -1,0 +1,66 @@
+name: ntttcp
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ntttcp.yml"
+      - "ports/ntttcp/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/ntttcp.yml"
+      - "ports/ntttcp/**"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        qnx_env: ["710", "800"]
+    name: Build for QNX ${{ matrix.qnx_env }}
+    runs-on: self-hosted
+    if: |
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'ntttcp'))
+    steps:
+      - name: Checkout build-files
+        uses: actions/checkout@v4
+        with:
+          path: build-files
+
+      - name: Checkout ntttcp
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/ntttcp-for-linux
+          path: ntttcp
+          ref: b483afe00b9b095e8bf56c01308d81aeae0cb53c
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Pull build environment
+        run: |
+          docker pull ghcr.io/qnx-ports/sdp-build-env:latest
+
+      - name: Build ntttcp
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/qnx-ports/sdp-build-env:latest
+          options: -v ${{ github.workspace }}:/home/runner/workspace -e MAKEFLAGS=${{ env.MAKEFLAGS }}
+          shell: bash
+          run: |
+            if [[ ${{ matrix.qnx_env }} == 710 ]]; then
+              source ~/qnx/710/qnxsdp-env.sh
+            else
+              source ~/qnx/800/qnxsdp-env.sh
+            fi
+            cd ~/workspace
+            make -C build-files/ports/ntttcp install

--- a/ports/ntttcp/.gitignore
+++ b/ports/ntttcp/.gitignore
@@ -1,0 +1,5 @@
+# QNX Build Files
+nto-aarch64-le/*
+nto-x86_64-o/*
+!nto-aarch64-le/Makefile
+!nto-x86_64-o/Makefile

--- a/ports/ntttcp/Makefile
+++ b/ports/ntttcp/Makefile
@@ -1,0 +1,9 @@
+LIST=OS
+EARLY_DIRS=lib util
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/ntttcp/README.md
+++ b/ports/ntttcp/README.md
@@ -1,0 +1,43 @@
+**NOTE**: QNX ports are only supported from a Linux host operating system
+**NOTE**: ntttcp-for-linux we are porting till commit/b483afe00b9b095e8bf56c01308d81aeae0cb53c, last official release was on 2019. so after that there are no official releases but resolved few major security issues
+
+Use `$(nproc)` instead of `4` after `JLEVEL=` and `-j` if you want to use the maximum number of cores to build this project.
+32GB of RAM is recommended for using `JLEVEL=$(nproc)` or `-j$(nproc)`.
+
+# Compile the port for QNX in a Docker container
+
+Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+```bash
+# Create a workspace
+mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+
+# Build the Docker image and create a container
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+# source qnxsdp-env.sh in
+source ~/qnx800/qnxsdp-env.sh
+
+# Clone ntttcp-for-linux
+cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/ntttcp-for-linux.git
+
+# Build ntttcp-for-linux
+BUILD_TESTING="ON" QNX_PROJECT_ROOT="$(pwd)/ntttcp-for-linux/src" make -C build-files/ports/ntttcp install -j4
+```
+
+# Compile the port for QNX on Ubuntu host
+```bash
+# Clone the repos
+mkdir -p ~/qnx_workspace && cd qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+git clone https://github.com/qnx-ports/ntttcp-for-linux.git
+
+# source qnxsdp-env.sh
+source ~/qnx800/qnxsdp-env.sh
+
+# Build ntttcp-for-linux
+BUILD_TESTING="ON" QNX_PROJECT_ROOT="$(pwd)/ntttcp-for-linux/src" make -C build-files/ports/ntttcp install -j4
+```

--- a/ports/ntttcp/README.md
+++ b/ports/ntttcp/README.md
@@ -26,6 +26,11 @@ git clone https://github.com/qnx-ports/ntttcp-for-linux.git
 
 # Build ntttcp-for-linux
 BUILD_TESTING="ON" QNX_PROJECT_ROOT="$(pwd)/ntttcp-for-linux/src" make -C build-files/ports/ntttcp install -j4
+
+**NOTE**: for building 710 use io-sock library for socket.
+download io-sock from http://anvil-server-n1.bts.rim.net/client/index.html#/packageDetails/com.qnx.qnx710.target.net.iosock/0.0.2.00622T202102120033S
+build:
+BUILD_TESTING="ON" QNX_PROJECT_ROOT="$(pwd)/ntttcp-for-linux/src" make -C build-files/ports/ntttcp USE_IOSOCK=true install
 ```
 
 # Compile the port for QNX on Ubuntu host
@@ -40,4 +45,9 @@ source ~/qnx800/qnxsdp-env.sh
 
 # Build ntttcp-for-linux
 BUILD_TESTING="ON" QNX_PROJECT_ROOT="$(pwd)/ntttcp-for-linux/src" make -C build-files/ports/ntttcp install -j4
+
+**NOTE**: for building 710 use io-sock library for socket.
+download io-sock from http://anvil-server-n1.bts.rim.net/client/index.html#/packageDetails/com.qnx.qnx710.target.net.iosock/0.0.2.00622T202102120033S
+build:
+BUILD_TESTING="ON" QNX_PROJECT_ROOT="$(pwd)/ntttcp-for-linux/src" make -C build-files/ports/ntttcp USE_IOSOCK=true install
 ```

--- a/ports/ntttcp/common.mk
+++ b/ports/ntttcp/common.mk
@@ -1,0 +1,99 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+include $(MKFILES_ROOT)/qmacros.mk
+
+NAME=ntttcp
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+BUILD_TESTING ?= OFF
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = ntttcp_all
+.PHONY: ntttcp_all install check clean
+
+# Default to true, but allow override from command line
+
+# Add io-sock support
+ifeq ($(USE_IOSOCK),true)
+ifeq ($(wildcard $(QNX_TARGET)/$(CPUVARDIR)/io-sock),)
+    $(error USE_IOSOCK is defined but io-sock is not found inside SDP. Note that io-sock is already the default network stack since QNX SDP 8.0.0. For SDP 7.1.0 and earlier, please ensure io-sock is downloaded via QSC first.)
+endif
+    $(info Linking to io-sock libsocket...)
+    IOSOCK_LDFLAGS = -L$(QNX_TARGET)/$(CPUVARDIR)/io-sock/lib -Wl,--as-needed -lsocket -Wl,--no-as-needed
+    IOSOCK_CFLAGS = -I$(QNX_TARGET)/usr/include/io-sock
+endif
+
+CFLAGS += $(FLAGS) -D_QNX_SOURCE $(IOSOCK_CFLAGS)
+LDFLAGS += -Wl,--build-id=md5, -lregex $(IOSOCK_LDFLAGS)
+include $(MKFILES_ROOT)/qtargets.mk
+
+#Search paths for all of CMake's find_* functions --
+#headers, libraries, etc.
+#
+#$(QNX_TARGET): for architecture-agnostic files shipped with SDP (e.g. headers)
+#$(QNX_TARGET)/$(CPUVARDIR): for architecture-specific files in SDP
+#$(INSTALL_ROOT)/$(CPUVARDIR): any packages that may have been installed in the staging area
+CMAKE_FIND_ROOT_PATH := $(QNX_TARGET);$(QNX_TARGET)/$(CPUVARDIR);$(INSTALL_ROOT)/$(CPUVARDIR)
+
+#Path to CMake modules; These are CMake files installed by other packages
+#for downstreams to discover them automatically. We support discovering
+#CMake-based packages from inside SDP or in the staging area.
+#Note that CMake modules can automatically detect the prefix they are
+#installed in.
+CMAKE_MODULE_PATH := $(QNX_TARGET)/$(CPUVARDIR)/$(PREFIX)/lib/cmake;$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib/cmake
+
+#Headers from INSTALL_ROOT need to be made available by default
+#because CMake and pkg-config do not necessary add it automatically
+#if the include path is "default"
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX="$(PREFIX)" \
+             -DCMAKE_STAGING_PREFIX="$(INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)" \
+             -DCMAKE_MODULE_PATH="$(CMAKE_MODULE_PATH)" \
+             -DCMAKE_INSTALL_INCLUDEDIR="$(INSTALL_ROOT)/$(PREFIX)/include" \
+             -DCMAKE_FIND_ROOT_PATH="$(CMAKE_FIND_ROOT_PATH)" \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DBUILD_SHARED_LIBS=1 \
+             -DCMAKE_HAVE_LIBC_PTHREAD=1 \
+
+
+ifndef NO_TARGET_OVERRIDE
+ntttcp_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: ntttcp_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install all $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -rf build
+
+uninstall:
+endif

--- a/ports/ntttcp/nto-aarch64-le/Makefile
+++ b/ports/ntttcp/nto-aarch64-le/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64le

--- a/ports/ntttcp/nto-x86_64-o/Makefile
+++ b/ports/ntttcp/nto-x86_64-o/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64

--- a/ports/ntttcp/qnx.nto.toolchain.cmake
+++ b/ports/ntttcp/qnx.nto.toolchain.cmake
@@ -1,0 +1,27 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+set(QNX_HOST "$ENV{QNX_HOST}")
+set(QNX_TARGET "$ENV{QNX_TARGET}")
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS} -D_QNX_SOURCE -I${QNX_TARGET}/usr/include/io-sock -I${QNX_TARGET}/usr/include/io-pkt" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} -std=gnu++14 ${EXTRA_CMAKE_CXX_FLAGS} -D_QNX_SOURCE" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")


### PR DESCRIPTION
NTTTCP is a multi-threaded Linux network throughput benchmark tool. 

While we are successfully able to measure network throughput, retrieving detailed system metrics has proven more challenging due to differences between Linux and QNX.

On Linux, we rely on system files such as /proc/net/netstat, /proc/interrupts, and /proc/cpuinfo to gather CPU and interrupt-related statistics. These interfaces are not available on QNX.

For QNX, we plan to explore accessing system-level data via the syspage interface, which may allow us to retrieve similar information (e.g., CPU topology, interrupts). 
Reference: https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.lib_ref/topic/s/syspage_entry.html).

Since throughput measurement is our primary objective and is already working, we will defer the remaining system-level metric integration to a later phase.