### PR TITLE
fontconfig gettext-runtime harfbuzz libiconv: Use ftpmirror.gnu.org instead of ftp.gnu.org

### DIFF
--- a/ports/fontconfig/install_all.sh
+++ b/ports/fontconfig/install_all.sh
@@ -6,7 +6,7 @@ DEP_CLONE_CMD=("git clone -b R_2_6_4 https://github.com/libexpat/libexpat.git"
                "echo"
                "git clone -b VER-2-13-3 https://gitlab.freedesktop.org/freetype/freetype.git")
 
-wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz && tar -xf libiconv-1.18.tar.gz
+wget https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz && tar -xf libiconv-1.18.tar.gz
 DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))
 

--- a/ports/gettext-runtime/README.md
+++ b/ports/gettext-runtime/README.md
@@ -21,7 +21,7 @@ Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/u
 # Create a workspace
 mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
 git clone https://github.com/qnx-ports/build-files.git
-wget https://ftp.gnu.org/pub/gnu/gettext/gettext-0.23.1.tar.gz && tar -xf gettext-0.23.1.tar.gz
+wget https://ftpmirror.gnu.org/gnu/gettext/gettext-0.23.1.tar.gz && tar -xf gettext-0.23.1.tar.gz
 
 # Optionally Build the Docker image and create a container
 cd build-files/docker

--- a/ports/harfbuzz/install_all.sh
+++ b/ports/harfbuzz/install_all.sh
@@ -8,8 +8,8 @@ DEP_CLONE_CMD=("git clone -b 1.3.14 https://github.com/silnrsi/graphite.git"
                "git clone -b VER-2-13-3 https://gitlab.freedesktop.org/freetype/freetype.git"
                "git clone -b 1.18.2 https://gitlab.freedesktop.org/cairo/cairo.git")
 
-wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz && tar -xf libiconv-1.18.tar.gz
-wget https://ftp.gnu.org/pub/gnu/gettext/gettext-0.23.1.tar.gz && tar -xf gettext-0.23.1.tar.gz
+wget https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz && tar -xf libiconv-1.18.tar.gz
+wget https://ftpmirror.gnu.org/gnu/gettext/gettext-0.23.1.tar.gz && tar -xf gettext-0.23.1.tar.gz
 
 DEP_COUNT=${#DEP_NAME[@]}
 DEP_COUNT=$(( DEP_COUNT - 1 ))

--- a/ports/libiconv/README.md
+++ b/ports/libiconv/README.md
@@ -18,7 +18,7 @@ Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/u
 # Create a workspace
 mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
 git clone https://github.com/qnx-ports/build-files.git
-wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz && tar -xf libiconv-1.18.tar.gz
+wget https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz && tar -xf libiconv-1.18.tar.gz
 
 # Optionally Build the Docker image and create a container
 cd build-files/docker


### PR DESCRIPTION
A handful of ports download tarballs directly from "ftp.gnu.org".

The FSF recommends using "ftpmirror.gnu.org" instead so a mirror close to your location can be automatically used. Switch over to using it.

QNXE-942