### PR TITLE
sdp-build-env: update to use newer curl for SDP7.1

### DIFF
--- a/.github/workflows/sdp-build-env.yml
+++ b/.github/workflows/sdp-build-env.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build-sdp-image:
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     if: |
       ((github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||


### PR DESCRIPTION
Hello,
I see current version of curl in SDP 7.1 lacking `ares_addrinfo` struct. On checking locally, default conservative SDP7.1 downloads correct `ares.h` header containing the structure, but one present in CI does not have it. This causes [nghttp2 build](https://github.com/qnx-ports/build-files/pull/244) to fail for 7.1. Hence this update.

Note: I am unsure about propagating this changed SDP to `ubuntu-common-22.04` environment and appreciate @eleir9268's advice