### PR TITLE
Add minicom build-files

### DIFF
--- a/.github/workflows/minicom.yml
+++ b/.github/workflows/minicom.yml
@@ -1,0 +1,63 @@
+name: minicom
+
+permissions:
+  contents: write
+  checks: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/minicom.yml'
+      - 'ports/minicom/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/minicom.yml'
+      - 'ports/minicom/**'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        qnx_env: ["710", "800"]
+
+    name: Build minicom 2.10 for QNX ${{ matrix.qnx_env }}
+    runs-on: ubuntu-22.04-common
+
+    if: |
+      ((github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.title, 'minicom')))
+
+    steps:
+      - name: Checkout build-files
+        uses: actions/checkout@v4
+        with:
+          repository: qnx-ports/build-files
+          path: build-files
+
+      - name: Checkout minicom source (v2.10)
+        uses: actions/checkout@v4
+        with:
+          repository: minicom-team/minicom
+          ref: "2.10"
+          path: minicom
+
+      - name: Set up QNX environment and build
+        shell: bash
+        run: |
+          if [[ "${{ matrix.qnx_env }}" == "800" ]]; then
+            source ~/qnx800/qnxsdp-env.sh
+          else
+            source ~/qnx710/qnxsdp-env.sh
+          fi
+          
+          QNX_PROJECT_ROOT="$(pwd)/minicom" \
+          make -C build-files/ports/minicom clean
+          
+          QNX_PROJECT_ROOT="$(pwd)/minicom" \
+          make -C build-files/ports/minicom install

--- a/.github/workflows/minicom.yml
+++ b/.github/workflows/minicom.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout minicom source (v2.10)
         uses: actions/checkout@v4
         with:
-          repository: minicom-team/minicom
+          repository: Distrotech/minicom
           ref: "2.10"
           path: minicom
 

--- a/.github/workflows/minicom.yml
+++ b/.github/workflows/minicom.yml
@@ -40,12 +40,11 @@ jobs:
           repository: qnx-ports/build-files
           path: build-files
 
-      - name: Checkout minicom source (v2.10)
-        uses: actions/checkout@v4
-        with:
-          repository: Distrotech/minicom
-          ref: "2.10"
-          path: minicom
+      - name: Download minicom 2.10
+        run: |
+          wget https://salsa.debian.org/minicom-team/minicom/-/archive/2.10/minicom-2.10.tar.gz
+          tar -xzf minicom-2.10.tar.gz
+          mv minicom-2.10 minicom
 
       - name: Set up QNX environment and build
         shell: bash

--- a/.github/workflows/minicom.yml
+++ b/.github/workflows/minicom.yml
@@ -50,9 +50,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.qnx_env }}" == "800" ]]; then
-            source ~/qnx800/qnxsdp-env.sh
+            source ~/qnx/800/qnxsdp-env.sh
           else
-            source ~/qnx710/qnxsdp-env.sh
+            source ~/qnx/710/qnxsdp-env.sh
           fi
           
           QNX_PROJECT_ROOT="$(pwd)/minicom" \

--- a/ports/minicom/.gitignore
+++ b/ports/minicom/.gitignore
@@ -1,0 +1,7 @@
+# Ignore all files under these two directories…
+nto-aarch64-le/*
+nto-x86_64-o/*
+
+# …but do not ignore the GNUmakefile in each
+!nto-aarch64-le/GNUmakefile
+!nto-x86_64-o/GNUmakefile

--- a/ports/minicom/Makefile
+++ b/ports/minicom/Makefile
@@ -1,0 +1,3 @@
+LIST=OS CPU VARIANT
+MAKEFILE=GNUmakefile
+include recurse.mk

--- a/ports/minicom/README.md
+++ b/ports/minicom/README.md
@@ -1,5 +1,4 @@
 # minicom [![Build](https://github.com/qnx-ports/build-files/actions/workflows/minicom.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/minicom.yml)
-# Compile the port for QNX
 
 **Note**: QNX ports are only supported from a **Linux host** operating system
 

--- a/ports/minicom/README.md
+++ b/ports/minicom/README.md
@@ -1,3 +1,4 @@
+# minicom [![Build](https://github.com/qnx-ports/build-files/actions/workflows/minicom.yml/badge.svg)](https://github.com/qnx-ports/build-files/actions/workflows/minicom.yml)
 # Compile the port for QNX
 
 **Note**: QNX ports are only supported from a **Linux host** operating system

--- a/ports/minicom/README.md
+++ b/ports/minicom/README.md
@@ -32,7 +32,7 @@ cd ~/qnx_workspace
 git clone https://salsa.debian.org/minicom-team/minicom.git
 git checkout 2.10
 
-# Build gmp
+# Build minicom
 QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom clean 
 QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom install JLEVEL=4
 
@@ -56,7 +56,7 @@ cd ~/qnx_workspace
 git clone https://salsa.debian.org/minicom-team/minicom.git
 git checkout 2.10
 
-# Build gmp
+# Build minicom
 QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom clean 
 QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom install JLEVEL=4
 ```

--- a/ports/minicom/README.md
+++ b/ports/minicom/README.md
@@ -1,0 +1,80 @@
+# Compile the port for QNX
+
+**Note**: QNX ports are only supported from a **Linux host** operating system
+
+Use `$(nproc)` instead of `4` after `JLEVEL=` and `-j` if you want to use the maximum number of cores to build this project.
+32GB of RAM is recommended for using `JLEVEL=$(nproc)` or `-j$(nproc)`.
+
+# Compile the port for QNX in a Docker container
+
+Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+
+```bash
+# Create a workspace
+mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+
+# Build the Docker image and create a container
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+# Now you are in the Docker container
+
+# Source SDP environment
+# for 7.1
+source ~/qnx710/qnxsdp-env.sh
+# for 8.0
+source ~/qnx800/qnxsdp-env.sh
+cd ~/qnx_workspace
+
+#clone minicom
+git clone https://salsa.debian.org/minicom-team/minicom.git
+git checkout 2.10
+
+# Build gmp
+QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom clean 
+QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom install JLEVEL=4
+
+```
+
+# Compile the port for QNX on Ubuntu host
+
+```bash
+# Clone the repos
+mkdir -p ~/qnx_workspace && cd qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+
+# Source SDP environment
+# for 7.1
+source ~/qnx710/qnxsdp-env.sh
+# for 8.0
+source ~/qnx800/qnxsdp-env.sh
+cd ~/qnx_workspace
+
+#clone minicom
+git clone https://salsa.debian.org/minicom-team/minicom.git
+git checkout 2.10
+
+# Build gmp
+QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom clean 
+QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom install JLEVEL=4
+```
+# How to test
+```bash
+
+export TARGET_HOST=<target-ip-address-or-hostname>
+mkdir minicom
+
+# Copy the dependency libraries for testing
+scp $QNX_TARGET/aarch64le/usr/local/bin/minicom   qnxuser@$TARGET_HOST:~/minicom
+
+```
+
+on Target
+```bash
+cd ~/minicom
+
+./minicom -D /dev/ser1
+
+```

--- a/ports/minicom/README.md
+++ b/ports/minicom/README.md
@@ -30,7 +30,7 @@ cd ~/qnx_workspace
 
 #clone minicom
 git clone https://salsa.debian.org/minicom-team/minicom.git
-git checkout 2.10
+cd minicom && git checkout 2.10
 
 # Build minicom
 QNX_PROJECT_ROOT="$(pwd)/minicom" make -C build-files/ports/minicom clean 

--- a/ports/minicom/README.md
+++ b/ports/minicom/README.md
@@ -74,7 +74,6 @@ scp $QNX_TARGET/aarch64le/usr/local/bin/minicom   qnxuser@$TARGET_HOST:~/minicom
 on Target
 ```bash
 cd ~/minicom
-
 ./minicom -D /dev/ser1
 
 ```

--- a/ports/minicom/build-hooks
+++ b/ports/minicom/build-hooks
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+NESTED_LEVEL="${QNX_PROJECT_ROOT:-../../..}"  
+BASIC_PREFIX="/usr/local"
+EXEC_PREFIX="/${cpudir}${BASIC_PREFIX}"
+
+function hook_preconfigure {
+    echo "hook_preconfigure - running autogen.sh in ${NESTED_LEVEL}"
+
+    unset AUTOMAKE AUTOCONF AUTOHEADER AUTORECONF ACLOCAL
+    export DESTDIR="${INSTALL_ROOT_nto}"
+
+    if [ ! -x "${NESTED_LEVEL}/configure" ]; then
+        (cd "${NESTED_LEVEL}" && ./autogen.sh)
+    fi
+}
+
+function hook_configure {
+    echo "hook_configure - running configure for minicom"
+
+    export FORCE_CROSS_COMPILING=yes
+    export PKG_CONFIG_LIBDIR=${DESTDIR}/usr/local/lib/pkgconfig
+    
+    ${NESTED_LEVEL}/configure \
+        --srcdir=${NESTED_LEVEL} \
+        --prefix=${BASIC_PREFIX} \
+        --exec-prefix=${EXEC_PREFIX} \
+        --host=${machine} \
+        --includedir=${BASIC_PREFIX}/include \
+        CFLAGS="-O2 -Wall" \
+        CPPFLAGS="${CPPFLAGS}" \
+        LDFLAGS="${LDFLAGS}" \
+        || exit 1
+}
+
+function hook_make {
+    echo "hook_make - running make ${make_cmds}"
+
+    INSTALL_ROOT="${INSTALL_ROOT_nto}"
+    FixMakeEnvironment
+
+    if [ "${make_cmds}" = "install" ]; then
+        make ${JLEVEL:+-j${JLEVEL}} install || exit 1
+        find ${INSTALL_ROOT_nto} -name "*.la" -exec rm -f {} \;
+    else
+        make ${JLEVEL:+-j${JLEVEL}} ${make_cmds} || exit 1
+    fi
+}

--- a/ports/minicom/common.mk
+++ b/ports/minicom/common.mk
@@ -1,0 +1,11 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+include $(MKFILES_ROOT)/qmake-cfg.mk
+
+ifndef NO_TARGET_OVERRIDE
+clean:
+	@ls -A | grep -v "GNUmakefile" | xargs -n 1 rm -rf
+endif

--- a/ports/minicom/nto-aarch64-le/GNUmakefile
+++ b/ports/minicom/nto-aarch64-le/GNUmakefile
@@ -1,0 +1,1 @@
+include ../common.mk

--- a/ports/minicom/nto-x86_64-o/GNUmakefile
+++ b/ports/minicom/nto-x86_64-o/GNUmakefile
@@ -1,0 +1,1 @@
+include ../common.mk


### PR DESCRIPTION
Add minicom 2.10 port for QNX (SDP 7.1 and 8.0).
Built and tested it successfully.
Functionalities were verified by launching and configuring minicom on a QNX 8 image using ./minicom -D /dev/ser1.