### PR TITLE
boost: use Python 3.13 instead of 3.11

### DIFF
--- a/ports/boost/common.mk
+++ b/ports/boost/common.mk
@@ -25,9 +25,9 @@ PREFIX ?= /usr/local
 
 BOOST_CPP_VERSION_FLAG ?= -std=c++11
 
-ifneq ($(wildcard $(QNX_TARGET)/usr/include/python3.11),)
-	PYTHON_VERSION = 3.11
-	PYTHON_USER_CONFIG=user-config-python311.jam
+ifneq ($(wildcard $(QNX_TARGET)/usr/include/python3.13),)
+	PYTHON_VERSION = 3.13
+	PYTHON_USER_CONFIG=user-config-python313.jam
 else
 	PYTHON_VERSION = 3.8
 	PYTHON_USER_CONFIG=user-config-python38.jam

--- a/ports/boost/user-config-python313.jam
+++ b/ports/boost/user-config-python313.jam
@@ -4,9 +4,9 @@ local QNX_TARGET = [ os.environ QNX_TARGET ] ;
 local CPUVARDIR = [ os.environ CPUVARDIR ] ;
 
 using python
-     : 3.11
+     : 3.13
      : python3
-     : $(QNX_TARGET)/$(CPUVARDIR)/usr/include/python3.11 $(QNX_TARGET)/usr/include/python3.11 $(QNX_TARGET)/usr/include/$(CPUVARDIR)/python3.11
+     : $(QNX_TARGET)/$(CPUVARDIR)/usr/include/python3.13 $(QNX_TARGET)/usr/include/python3.13 $(QNX_TARGET)/usr/include/$(CPUVARDIR)/python3.13
      : $(QNX_TARGET)/$(CPUVARDIR)/usr/lib
      : <target-os>qnxnto <toolset>qcc
      ;


### PR DESCRIPTION
Python 3.13 is now available in the 8.0 SDP.