### PR TITLE
sdp-build-env: update and push run trigger

### DIFF
--- a/.github/workflows/sdp-build-env.yml
+++ b/.github/workflows/sdp-build-env.yml
@@ -90,5 +90,5 @@ jobs:
     - name: Push to ghcr.io
       if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
       run: |
-        # Push changes
+        # Push the image
         buildah push ghcr.io/qnx-ports/sdp-build-env:latest


### PR DESCRIPTION
This job is to trigger "push" for uploading SDP image to ghcr.io/qnx-ports package registry