### PR TITLE
Add build files for Snappy, double-conversion, libwebp and FLAC

### DIFF
--- a/ports/FLAC/LICENSE.md
+++ b/ports/FLAC/LICENSE.md
@@ -1,0 +1,7 @@
+This license covers all the content of the qnx folder except where a license is included in a file
+
+
+Copyright (c) 2023, BlackBerry Limited. All Rights Reserved.
+
+This project is dual licensed under the Eclipse Public License 2.0 and the
+Eclipse Distribution License 1.0 as described in the epl-v20 and edl-v10 files.

--- a/ports/FLAC/Makefile
+++ b/ports/FLAC/Makefile
@@ -1,0 +1,8 @@
+LIST=OS
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/FLAC/README.md
+++ b/ports/FLAC/README.md
@@ -1,0 +1,60 @@
+# FLAC
+
+**NOTE**: QNX ports are only supported from a Linux host operating system.
+
+Use `$(nproc)` instead of `4` after `JLEVEL=` and `-j` if you want to use the maximum number of cores to build this project.
+32GB of RAM is recommended for using `JLEVEL=$(nproc)` or `-j$(nproc)`.
+
+# Compile the port for QNX in a Docker container
+
+Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+```bash
+# Create a workspace
+mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+
+# Build the Docker image and create a container
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+# source qnxsdp-env.sh in
+source ~/qnx800/qnxsdp-env.sh
+
+# Clone FLAC from upstream
+cd ~/qnx_workspace
+git clone https://github.com/xiph/flac.git
+
+# Build FLAC
+BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/flac" make -C build-files/ports/FLAC install -j4
+```
+
+# Compile the port for QNX on Ubuntu host
+
+```bash
+# Clone the repos
+git clone https://github.com/qnx-ports/build-files.git
+git clone https://github.com/xiph/flac.git
+
+# source qnxsdp-env.sh
+source ~/qnx800/qnxsdp-env.sh
+
+# Build
+BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/flac" make -C build-files/ports/FLAC install -j4
+```
+
+# How to run tests
+
+Make sure the directories exist on the target:
+```bash
+mkdir -p /data/home/qnxuser/snappy/lib
+```
+
+scp libraries and tests to the target (note, mDNS is configured from
+/boot/qnx_config.txt and uses qnxpi.local by default).
+```bash
+TARGET_HOST=<target-ip-address-or-hostname>
+
+scp $QNX_TARGET/aarch64le/usr/local/bin/snappy_unittest qnxuser@$TARGET_HOST:/data/home/qnxuser/snappy/
+scp $QNX_TARGET/aarch64le/usr/local/lib/libsnappy* qnxuser@$TARGET_HOST:/data/home/qnxuser/snappy/lib/
+```

--- a/ports/FLAC/common.mk
+++ b/ports/FLAC/common.mk
@@ -1,0 +1,66 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#where to install flac:
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+FLAC_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+BUILD_TESTING ?= OFF
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = flac_all
+.PHONY: flac_all
+
+FLAGS   += -g -D_QNX_SOURCE
+LDFLAGS += -lsocket
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(FLAC_INSTALL_ROOT) \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(FLAC_INSTALL_ROOT)/$(PREFIX)/include \
+             -DCMAKE_INSTALL_LIBDIR=$(FLAC_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib \
+             -DCMAKE_INSTALL_BINDIR=$(FLAC_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/bin \
+             -DCMAKE_SHARED_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_EXE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_C_FLAGS="$(FLAGS)" \
+             -DCMAKE_CXX_FLAGS="$(FLAGS)" \
+             -DWITH_OGG=OFF \
+             -DINSTALL_MANPAGES=OFF \
+             -DBUILD_PROGRAMS=OFF \
+             -DBUILD_TESTING=$(BUILD_TESTING)
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+ifndef NO_TARGET_OVERRIDE
+flac_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install: flac_all
+	@cd build && make install $(MAKE_ARGS)
+
+clean iclean spotless:
+	@rm -fr build
+
+cuninstall uninstall:
+
+endif

--- a/ports/FLAC/nto-aarch64-le/Makefile
+++ b/ports/FLAC/nto-aarch64-le/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64le

--- a/ports/FLAC/nto-x86_64-o/Makefile
+++ b/ports/FLAC/nto-x86_64-o/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64

--- a/ports/FLAC/qnx.nto.toolchain.cmake
+++ b/ports/FLAC/qnx.nto.toolchain.cmake
@@ -1,0 +1,43 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+if ("${GCC_VER}" STREQUAL "")
+    set(GCC_VERSION "" CACHE STRING "gcc_ver")
+else()
+    set(GCC_VERSION "${GCC_VER}," CACHE STRING "gcc_ver")
+endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")
+
+set(CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries.")
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/ports/double-conversion/LICENSE.md
+++ b/ports/double-conversion/LICENSE.md
@@ -1,0 +1,7 @@
+This license covers all the content of the qnx folder except where a license is included in a file
+
+
+Copyright (c) 2023, BlackBerry Limited. All Rights Reserved.
+
+This project is dual licensed under the Eclipse Public License 2.0 and the
+Eclipse Distribution License 1.0 as described in the epl-v20 and edl-v10 files.

--- a/ports/double-conversion/Makefile
+++ b/ports/double-conversion/Makefile
@@ -1,0 +1,8 @@
+LIST=OS
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/double-conversion/README.md
+++ b/ports/double-conversion/README.md
@@ -1,4 +1,4 @@
-# FLAC
+# double-conversion
 
 **NOTE**: QNX ports are only supported from a Linux host operating system.
 
@@ -23,10 +23,10 @@ source ~/qnx800/qnxsdp-env.sh
 
 # Clone FLAC from upstream
 cd ~/qnx_workspace
-git clone https://github.com/xiph/flac.git
+git clone https://github.com/google/double-conversion.git
 
 # Build FLAC
-BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/flac" make -C build-files/ports/FLAC install -j4
+BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/double-conversion" make -C build-files/ports/double-conversion install -j4
 ```
 
 # Compile the port for QNX on Ubuntu host
@@ -34,24 +34,28 @@ BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/flac" make -C build-files/ports/FLAC i
 ```bash
 # Clone the repos
 git clone https://github.com/qnx-ports/build-files.git
-git clone https://github.com/xiph/flac.git
+git clone https://github.com/google/double-conversion.git
 
 # source qnxsdp-env.sh
 source ~/qnx800/qnxsdp-env.sh
 
 # Build
-BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/flac" make -C build-files/ports/FLAC install -j4
+BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/double-conversion" make -C build-files/ports/double-conversion install -j4
 ```
 
 # How to run tests
 
 Make sure the directories exist on the target:
 ```bash
-mkdir -p /data/home/qnxuser/flac/lib
+mkdir -p /data/home/qnxuser/double-conversion/lib
 ```
+
 scp libraries and tests to the target (note, mDNS is configured from
 /boot/qnx_config.txt and uses qnxpi.local by default).
 
 ```bash
-TARGET_HOST=  scp $QNX_TARGET/aarch64le/usr/local/bin/flac qnxuser@$TARGET_HOST:/data/home/qnxuser/flac/scp $QNX_TARGET/aarch64le/usr/local/lib/libFLAC* qnxuser@$TARGET_HOST:/data/home/qnxuser/flac/lib/
+TARGET_HOST=
+
+scp $QNX_TARGET/aarch64le/usr/local/bin/cctest qnxuser@$TARGET_HOST:/data/home/qnxuser/double-conversion/
+scp $QNX_TARGET/aarch64le/usr/local/lib/libdouble-conversion* qnxuser@$TARGET_HOST:/data/home/qnxuser/double-conversion/lib/
 ```

--- a/ports/double-conversion/common.mk
+++ b/ports/double-conversion/common.mk
@@ -1,0 +1,65 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#where to install double-conversion:
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+DOUBLE_CONVERSION_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+BUILD_TESTING ?= OFF
+BUILD_SHARED_LIBS ?= ON
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = double_conversion_all
+.PHONY: double_conversion_all
+
+FLAGS   += -g -D_QNX_SOURCE
+LDFLAGS += -lsocket
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(DOUBLE_CONVERSION_INSTALL_ROOT) \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(DOUBLE_CONVERSION_INSTALL_ROOT)/$(PREFIX)/include \
+             -DCMAKE_INSTALL_LIBDIR=$(DOUBLE_CONVERSION_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib \
+             -DCMAKE_INSTALL_BINDIR=$(DOUBLE_CONVERSION_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/bin \
+             -DCMAKE_SHARED_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_EXE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_C_FLAGS="$(FLAGS)" \
+             -DCMAKE_CXX_FLAGS="$(FLAGS)" \
+             -DBUILD_TESTING=$(BUILD_TESTING) \
+             -DBUILD_SHARED_LIBS=$(BUILD_SHARED_LIBS)
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+ifndef NO_TARGET_OVERRIDE
+double_conversion_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install: double_conversion_all
+	@cd build && make install $(MAKE_ARGS)
+
+clean iclean spotless:
+	@rm -fr build
+
+cuninstall uninstall:
+
+endif

--- a/ports/double-conversion/nto-aarch64-le/Makefile
+++ b/ports/double-conversion/nto-aarch64-le/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64le

--- a/ports/double-conversion/nto-x86_64-o/Makefile
+++ b/ports/double-conversion/nto-x86_64-o/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64

--- a/ports/double-conversion/qnx.nto.toolchain.cmake
+++ b/ports/double-conversion/qnx.nto.toolchain.cmake
@@ -1,0 +1,43 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+if ("${GCC_VER}" STREQUAL "")
+    set(GCC_VERSION "" CACHE STRING "gcc_ver")
+else()
+    set(GCC_VERSION "${GCC_VER}," CACHE STRING "gcc_ver")
+endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")
+
+set(CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries.")
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/ports/libwebp/LICENSE.md
+++ b/ports/libwebp/LICENSE.md
@@ -1,0 +1,7 @@
+This license covers all the content of the qnx folder except where a license is included in a file
+
+
+Copyright (c) 2023, BlackBerry Limited. All Rights Reserved.
+
+This project is dual licensed under the Eclipse Public License 2.0 and the
+Eclipse Distribution License 1.0 as described in the epl-v20 and edl-v10 files.

--- a/ports/libwebp/Makefile
+++ b/ports/libwebp/Makefile
@@ -1,0 +1,8 @@
+LIST=OS
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/libwebp/README.md
+++ b/ports/libwebp/README.md
@@ -1,4 +1,4 @@
-# double-conversion
+# libwebp
 
 **NOTE**: QNX ports are only supported from a Linux host operating system.
 
@@ -21,12 +21,12 @@ cd build-files/docker
 # source qnxsdp-env.sh in
 source ~/qnx800/qnxsdp-env.sh
 
-# Clone double-conversion from upstream
+# Clone libwebp from upstream
 cd ~/qnx_workspace
-git clone https://github.com/google/double-conversion.git
+git clone https://chromium.googlesource.com/webm/libwebp
 
-# Build double-conversion
-BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/double-conversion" make -C build-files/ports/double-conversion install -j4
+# Build libwebp
+QNX_PROJECT_ROOT="$(pwd)/libwebp" make -C build-files/ports/libwebp install -j4
 ```
 
 # Compile the port for QNX on Ubuntu host
@@ -34,28 +34,28 @@ BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/double-conversion" make -C build-files
 ```bash
 # Clone the repos
 git clone https://github.com/qnx-ports/build-files.git
-git clone https://github.com/google/double-conversion.git
+git clone https://chromium.googlesource.com/webm/libwebp
 
 # source qnxsdp-env.sh
 source ~/qnx800/qnxsdp-env.sh
 
 # Build
-BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/double-conversion" make -C build-files/ports/double-conversion install -j4
+QNX_PROJECT_ROOT="$(pwd)/libwebp" make -C build-files/ports/libwebp install -j4
 ```
 
 # How to run tests
 
 Make sure the directories exist on the target:
 ```bash
-mkdir -p /data/home/qnxuser/double-conversion/lib
+mkdir -p /data/home/qnxuser/libwebp/lib
 ```
 
 scp libraries and tests to the target (note, mDNS is configured from
 /boot/qnx_config.txt and uses qnxpi.local by default).
 
 ```bash
-TARGET_HOST=
+TARGET_HOST=<target-ip-address-or-hostname>
 
-scp $QNX_TARGET/aarch64le/usr/local/bin/cctest qnxuser@$TARGET_HOST:/data/home/qnxuser/double-conversion/
-scp $QNX_TARGET/aarch64le/usr/local/lib/libdouble-conversion* qnxuser@$TARGET_HOST:/data/home/qnxuser/double-conversion/lib/
+scp $QNX_TARGET/aarch64le/usr/local/lib/libwebp* qnxuser@$TARGET_HOST:/data/home/qnxuser/libwebp/lib/
+scp $QNX_TARGET/aarch64le/usr/local/lib/libsharpyuv* qnxuser@$TARGET_HOST:/data/home/qnxuser/libwebp/lib/
 ```

--- a/ports/libwebp/common.mk
+++ b/ports/libwebp/common.mk
@@ -1,0 +1,53 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+# Install path configuration
+LIBWEBP_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+PREFIX ?= /usr/local
+
+# Build configurations
+CMAKE_BUILD_TYPE ?= Release
+BUILD_SHARED_LIBS ?= ON
+
+# Override default QNX build targets
+ALL_DEPENDENCIES = libwebp_all
+.PHONY: libwebp_all
+
+FLAGS   += -g -D_QNX_SOURCE
+LDFLAGS += -lsocket
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(LIBWEBP_INSTALL_ROOT) \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(LIBWEBP_INSTALL_ROOT)/$(PREFIX)/include \
+             -DCMAKE_INSTALL_LIBDIR=$(LIBWEBP_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib \
+             -DCMAKE_INSTALL_BINDIR=$(LIBWEBP_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/bin \
+             -DCMAKE_SHARED_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_EXE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCMAKE_C_FLAGS="$(FLAGS)" \
+             -DCMAKE_CXX_FLAGS="$(FLAGS)" \
+             -DCMAKE_AR="$(QNX_HOST)/usr/bin/nto$(CPU)-ar" \
+             -DCMAKE_RANLIB="$(QNX_HOST)/usr/bin/nto$(CPU)-ranlib" \
+             -DBUILD_SHARED_LIBS=$(BUILD_SHARED_LIBS)
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+ifndef NO_TARGET_OVERRIDE
+libwebp_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install: libwebp_all
+	@cd build && make install $(MAKE_ARGS)
+
+clean iclean spotless:
+	@rm -fr build
+
+cuninstall uninstall:
+
+endif

--- a/ports/libwebp/nto-aarch64-le/Makefile
+++ b/ports/libwebp/nto-aarch64-le/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64le

--- a/ports/libwebp/nto-x86_64-o/Makefile
+++ b/ports/libwebp/nto-x86_64-o/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64

--- a/ports/libwebp/qnx.nto.toolchain.cmake
+++ b/ports/libwebp/qnx.nto.toolchain.cmake
@@ -1,0 +1,43 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+if ("${GCC_VER}" STREQUAL "")
+    set(GCC_VERSION "" CACHE STRING "gcc_ver")
+else()
+    set(GCC_VERSION "${GCC_VER}," CACHE STRING "gcc_ver")
+endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")
+
+set(CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries.")
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/ports/snappy/LICENSE.md
+++ b/ports/snappy/LICENSE.md
@@ -1,0 +1,7 @@
+This license covers all the content of the qnx folder except where a license is included in a file
+
+
+Copyright (c) 2023, BlackBerry Limited. All Rights Reserved.
+
+This project is dual licensed under the Eclipse Public License 2.0 and the
+Eclipse Distribution License 1.0 as described in the epl-v20 and edl-v10 files.

--- a/ports/snappy/Makefile
+++ b/ports/snappy/Makefile
@@ -1,0 +1,8 @@
+LIST=OS
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/ports/snappy/README.md
+++ b/ports/snappy/README.md
@@ -1,0 +1,80 @@
+# Snappy
+
+**NOTE**: QNX ports are only supported from a Linux host operating system
+
+Use `$(nproc)` instead of `4` after `JLEVEL=` and `-j` if you want to use the maximum number of cores to build this project.
+32GB of RAM is recommended for using `JLEVEL=$(nproc)` or `-j$(nproc)`.
+
+# Compile the port for QNX in a Docker container
+
+Pre-requisite: Install Docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/
+```bash
+# Create a workspace
+mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
+git clone https://github.com/qnx-ports/build-files.git
+
+# Build the Docker image and create a container
+cd build-files/docker
+./docker-build-qnx-image.sh
+./docker-create-container.sh
+
+# source qnxsdp-env.sh in
+source ~/qnx800/qnxsdp-env.sh
+
+# Clone snappy from upstream
+cd ~/qnx_workspace
+git clone https://github.com/google/snappy.git
+
+# Build snappy
+BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/snappy" make -C build-files/ports/snappy install -j4
+```
+
+# Compile the port for QNX on Ubuntu host
+
+```bash
+# Clone the repos
+git clone https://github.com/qnx-ports/build-files.git
+git clone https://github.com/google/snappy.git
+
+# source qnxsdp-env.sh
+source ~/qnx800/qnxsdp-env.sh
+
+# Build
+BUILD_TESTING=ON QNX_PROJECT_ROOT="$(pwd)/snappy" make -C build-files/ports/snappy install -j4
+```
+
+# How to run tests
+
+Make sure the directories exist on the target:
+```bash
+mkdir -p /data/home/qnxuser/snappy/lib
+```
+
+scp libraries and tests to the target (note, mDNS is configured from
+/boot/qnx_config.txt and uses qnxpi.local by default).
+```bash
+TARGET_HOST=<target-ip-address-or-hostname>
+
+scp $QNX_TARGET/aarch64le/usr/local/bin/snappy_unittest qnxuser@$TARGET_HOST:/data/home/qnxuser/snappy/
+scp $QNX_TARGET/aarch64le/usr/local/lib/libsnappy* qnxuser@$TARGET_HOST:/data/home/qnxuser/snappy/lib/
+```
+
+Run tests on the target.
+
+```bash
+# ssh into the target
+ssh qnxuser@$TARGET_HOST
+
+# Change directory to the test directory
+cd /data/home/qnxuser/snappy
+TEST_PATH=${PWD}
+
+# Add libs to LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib
+
+# Set permissions
+chmod +x snappy_unittest
+
+# Run snappy test
+./snappy_unittest
+```

--- a/ports/snappy/common.mk
+++ b/ports/snappy/common.mk
@@ -1,0 +1,68 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+QNX_PROJECT_ROOT ?= $(PRODUCT_ROOT)/../../
+
+#where to install snappy:
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+SNAPPY_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#A prefix path to use **on the target**. This is
+#different from INSTALL_ROOT, which refers to a
+#installation destination **on the host machine**.
+#This prefix path may be exposed to the source code,
+#the linker, or package discovery config files (.pc,
+#CMake config modules, etc.). Default is /usr/local
+PREFIX ?= /usr/local
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+BUILD_TESTING ?= OFF
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = snappy_all
+.PHONY: snappy_all
+
+FLAGS   += -g -D_QNX_SOURCE
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(SNAPPY_INSTALL_ROOT) \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DCMAKE_INSTALL_BINDIR=$(SNAPPY_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/bin \
+             -DCMAKE_INSTALL_INCLUDEDIR=$(SNAPPY_INSTALL_ROOT)/$(PREFIX)/include \
+             -DCMAKE_INSTALL_LIBDIR=$(SNAPPY_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/lib \
+             -DCMAKE_INSTALL_SBINDIR=$(SNAPPY_INSTALL_ROOT)/$(CPUVARDIR)/$(PREFIX)/sbin \
+             -DCMAKE_MODULE_PATH=$(PROJECT_ROOT) \
+             -DEXTRA_CMAKE_C_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DCPUVARDIR=$(CPUVARDIR) \
+             -DCXX_LIBTYPE=${CXX_LIBTYPE} \
+             -DGCC_VER=${GCC_VER} \
+             -DBUILD_TESTING=$(BUILD_TESTING)\
+             -DSNAPPY_BUILD_TESTS=$(BUILD_TESTING) \
+             -DSNAPPY_BUILD_BENCHMARKS=$(BUILD_TESTING)
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+ifndef NO_TARGET_OVERRIDE
+snappy_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(QNX_PROJECT_ROOT)
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install: snappy_all
+	@cd build && make install $(MAKE_ARGS)
+
+clean iclean spotless:
+	@rm -fr build
+
+cuninstall uninstall:
+
+endif

--- a/ports/snappy/nto-aarch64-le/Makefile
+++ b/ports/snappy/nto-aarch64-le/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64le

--- a/ports/snappy/nto-x86_64-o/Makefile
+++ b/ports/snappy/nto-x86_64-o/Makefile
@@ -1,0 +1,3 @@
+include ../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64

--- a/ports/snappy/qnx.nto.toolchain.cmake
+++ b/ports/snappy/qnx.nto.toolchain.cmake
@@ -1,0 +1,43 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/q++)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+if ("${GCC_VER}" STREQUAL "")
+    set(GCC_VERSION "" CACHE STRING "gcc_ver")
+else()
+    set(GCC_VERSION "${GCC_VER}," CACHE STRING "gcc_ver")
+endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")
+
+set(CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries.")
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
### Description
This PR adds the QNX build files for [Google Snappy](https://github.com/google/snappy), [double-conversion](https://github.com/google/double-conversion), [libwebp](https://chromium.googlesource.com/webm/libwebp) and [FLAC](https://github.com/xiph/flac)

### Changes Included
* Copied the Mosquitto port files (`common.mk`, Makefiles, and `README.md`) and updated them accordingly for Snappy, double-conversion, libwebp and FLAC
* Linked the CMake test and benchmark flags to the `BUILD_TESTING` variable (defaults to `OFF`) for snappy

### Testing (snappy)
* Successfully configured the build system using the QNX CMake toolchain.
* Tests can be compiled by passing `BUILD_TESTING=ON`.